### PR TITLE
Fix space leak when rebuilding UI and handling events

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,13 @@
 ### 1.0.0.3
 
 - Consume and forward all available messages from Producers on each cycle.
+- Add Nix and GitHub Actions support (thanks @smunix!).
+- Fix space leak when rebuilding the UI or handling events.
 
 ### 1.0.0.2
 
 - Use the recently published nanovg-0.8.0.0 from Hackage, instead of the version from the PR's commit.
-- Added `appRenderOnMainThread` option.
+- Add `appRenderOnMainThread` option.
 
 ### 1.0.0.1
 

--- a/examples/ticker/Main.hs
+++ b/examples/ticker/Main.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Main where
 
@@ -81,7 +82,7 @@ tickerRow wenv idx t = row where
       `styleHover` [bgColor rowBg]
 
 buildUI :: TickerWenv -> TickerModel -> TickerNode
-buildUI wenv model = widgetTree where
+buildUI !wenv model = widgetTree where
   sectionBg = wenv ^. L.theme . L.sectionColor
 
   tickerList = vstack tickerRows where

--- a/examples/ticker/Main.hs
+++ b/examples/ticker/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}

--- a/examples/ticker/Main.hs
+++ b/examples/ticker/Main.hs
@@ -1,8 +1,8 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns #-}
 
 module Main where
 
@@ -82,7 +82,7 @@ tickerRow wenv idx t = row where
       `styleHover` [bgColor rowBg]
 
 buildUI :: TickerWenv -> TickerModel -> TickerNode
-buildUI !wenv model = widgetTree where
+buildUI wenv model = widgetTree where
   sectionBg = wenv ^. L.theme . L.sectionColor
 
   tickerList = vstack tickerRows where

--- a/examples/ticker/TickerTypes.hs
+++ b/examples/ticker/TickerTypes.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+{-# LANGUAGE StrictData #-}
+
 module TickerTypes where
 
 import Control.Concurrent.STM.TChan

--- a/examples/ticker/TickerTypes.hs
+++ b/examples/ticker/TickerTypes.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-{-# LANGUAGE StrictData #-}
-
 module TickerTypes where
 
 import Control.Concurrent.STM.TChan

--- a/examples/tutorial/Main.hs
+++ b/examples/tutorial/Main.hs
@@ -1,21 +1,21 @@
 module Main where
 
---import qualified Tutorial01_Basics
---import qualified Tutorial02_Styling
---import qualified Tutorial03_LifeCycle
---import qualified Tutorial04_Tasks
+import qualified Tutorial01_Basics
+import qualified Tutorial02_Styling
+import qualified Tutorial03_LifeCycle
+import qualified Tutorial04_Tasks
 import qualified Tutorial05_Producers
---import qualified Tutorial06_Composite
---import qualified Tutorial07_CustomWidget
---import qualified Tutorial08_Themes
+import qualified Tutorial06_Composite
+import qualified Tutorial07_CustomWidget
+import qualified Tutorial08_Themes
 
 main :: IO ()
 main = do
 --  Tutorial01_Basics.main01
---  Tutorial02_Styling.main02
+  Tutorial02_Styling.main02
 --  Tutorial03_LifeCycle.main03
 --  Tutorial04_Tasks.main04
-  Tutorial05_Producers.main05
+--  Tutorial05_Producers.main05
 --  Tutorial06_Composite.main06
 --  Tutorial07_CustomWidget.main07
 --  Tutorial08_Themes.main08

--- a/examples/tutorial/Main.hs
+++ b/examples/tutorial/Main.hs
@@ -1,21 +1,21 @@
 module Main where
 
-import qualified Tutorial01_Basics
-import qualified Tutorial02_Styling
-import qualified Tutorial03_LifeCycle
-import qualified Tutorial04_Tasks
+--import qualified Tutorial01_Basics
+--import qualified Tutorial02_Styling
+--import qualified Tutorial03_LifeCycle
+--import qualified Tutorial04_Tasks
 import qualified Tutorial05_Producers
-import qualified Tutorial06_Composite
-import qualified Tutorial07_CustomWidget
-import qualified Tutorial08_Themes
+--import qualified Tutorial06_Composite
+--import qualified Tutorial07_CustomWidget
+--import qualified Tutorial08_Themes
 
 main :: IO ()
 main = do
 --  Tutorial01_Basics.main01
-  Tutorial02_Styling.main02
+--  Tutorial02_Styling.main02
 --  Tutorial03_LifeCycle.main03
 --  Tutorial04_Tasks.main04
---  Tutorial05_Producers.main05
+  Tutorial05_Producers.main05
 --  Tutorial06_Composite.main06
 --  Tutorial07_CustomWidget.main07
 --  Tutorial08_Themes.main08

--- a/examples/tutorial/Tutorial05_Producers.hs
+++ b/examples/tutorial/Tutorial05_Producers.hs
@@ -3,10 +3,6 @@
 
 module Tutorial05_Producers where
 
-import Control.Exception (bracket)
-import System.Remote.Monitoring
-import Control.Concurrent
-
 import Control.Concurrent (threadDelay)
 import Control.Lens
 import Data.Text (Text)
@@ -34,17 +30,11 @@ buildUI
 buildUI wenv model = widgetTree where
   timeString = T.pack . show $ model ^. currentTime
 
---  timeLabel = label (T.takeWhile (/= '.') timeString)
---    `styleBasic` [textFont "Bold", textSize 80, textCenter, textMiddle, flexHeight 100]
-
   timeLabel = label (T.takeWhile (/= '.') timeString)
-    `styleBasic` [textFont "Regular", textSize 20, textCenter, textMiddle, padding 10]
+    `styleBasic` [textFont "Bold", textSize 80, textCenter, textMiddle, flexHeight 100]
 
-  timeLabels = vstack (replicate 10 timeLabel)
-
---  widgetTree = timeLabel
   widgetTree = vstack [
-      animFadeIn timeLabels `nodeKey` "fadeTimeLabel"
+      animFadeIn timeLabel `nodeKey` "fadeTimeLabel"
     ]
 
 handleEvent
@@ -65,7 +55,7 @@ timeOfDayProducer :: (AppEvent -> IO ()) -> IO ()
 timeOfDayProducer sendMsg = do
   time <- getLocalTimeOfDay
   sendMsg (AppSetTime time)
-  threadDelay $ 1000 * 10
+  threadDelay $ 1000 * 1000
   timeOfDayProducer sendMsg
 
 getLocalTimeOfDay :: IO TimeOfDay
@@ -88,13 +78,3 @@ main05 = do
     model time = AppModel {
       _currentTime = time
     }
-
-withMonitoring :: IO a -> IO a
-withMonitoring action = do
-  bracket
-    startServer
-    stopServer
-    (const action)
-  where
-    startServer = forkServer "localhost" 28000
-    stopServer server = killThread (serverThreadId server)

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -188,92 +188,6 @@ library
         GLEW
   default-language: Haskell2010
 
-executable books
-  main-is: Main.hs
-  other-modules:
-      BookTypes
-      Paths_monomer
-  hs-source-dirs:
-      examples/books
-  default-extensions:
-      OverloadedStrings
-  ghc-options: -threaded
-  build-depends:
-      JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
-    , aeson >=1.4 && <1.6
-    , async >=2.1 && <2.3
-    , attoparsec >=0.12 && <0.15
-    , base >=4.11 && <5
-    , bytestring >=0.10 && <0.12
-    , bytestring-to-vector ==0.3.*
-    , containers >=0.5.11 && <0.7
-    , data-default >=0.5 && <0.8
-    , exceptions ==0.10.*
-    , extra >=1.6 && <1.9
-    , formatting >=6.0 && <8.0
-    , http-client >=0.6 && <0.9
-    , lens >=4.16 && <5.1
-    , monomer
-    , mtl >=2.1 && <2.3
-    , nanovg >=0.8 && <1.0
-    , process ==1.6.*
-    , safe ==0.3.*
-    , sdl2 >=2.4.0 && <2.6
-    , stm ==2.5.*
-    , text ==1.2.*
-    , text-show >=3.7 && <3.10
-    , time >=1.8 && <1.13
-    , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
-    , vector >=0.12 && <0.14
-    , wreq >=0.5.2 && <0.6
-  default-language: Haskell2010
-
-executable generative
-  main-is: Main.hs
-  other-modules:
-      GenerativeTypes
-      Widgets.BoxesPalette
-      Widgets.CirclesGrid
-      Paths_monomer
-  hs-source-dirs:
-      examples/generative
-  default-extensions:
-      OverloadedStrings
-  ghc-options: -threaded
-  build-depends:
-      JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
-    , async >=2.1 && <2.3
-    , attoparsec >=0.12 && <0.15
-    , base >=4.11 && <5
-    , bytestring >=0.10 && <0.12
-    , bytestring-to-vector ==0.3.*
-    , containers >=0.5.11 && <0.7
-    , data-default >=0.5 && <0.8
-    , exceptions ==0.10.*
-    , extra >=1.6 && <1.9
-    , formatting >=6.0 && <8.0
-    , http-client >=0.6 && <0.9
-    , lens >=4.16 && <5.1
-    , monomer
-    , mtl >=2.1 && <2.3
-    , nanovg >=0.8 && <1.0
-    , process ==1.6.*
-    , random >=1.1 && <1.3
-    , safe ==0.3.*
-    , sdl2 >=2.4.0 && <2.6
-    , stm ==2.5.*
-    , text ==1.2.*
-    , text-show >=3.7 && <3.10
-    , time >=1.8 && <1.13
-    , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
-    , vector >=0.12 && <0.14
-    , wreq >=0.5.2 && <0.6
-  default-language: Haskell2010
-
 executable ticker
   main-is: Main.hs
   other-modules:
@@ -320,47 +234,6 @@ executable ticker
     , wuss ==1.1.*
   default-language: Haskell2010
 
-executable todo
-  main-is: Main.hs
-  other-modules:
-      TodoTypes
-      Paths_monomer
-  hs-source-dirs:
-      examples/todo
-  default-extensions:
-      OverloadedStrings
-  ghc-options: -threaded
-  build-depends:
-      JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
-    , async >=2.1 && <2.3
-    , attoparsec >=0.12 && <0.15
-    , base >=4.11 && <5
-    , bytestring >=0.10 && <0.12
-    , bytestring-to-vector ==0.3.*
-    , containers >=0.5.11 && <0.7
-    , data-default >=0.5 && <0.8
-    , exceptions ==0.10.*
-    , extra >=1.6 && <1.9
-    , formatting >=6.0 && <8.0
-    , http-client >=0.6 && <0.9
-    , lens >=4.16 && <5.1
-    , monomer
-    , mtl >=2.1 && <2.3
-    , nanovg >=0.8 && <1.0
-    , process ==1.6.*
-    , safe ==0.3.*
-    , sdl2 >=2.4.0 && <2.6
-    , stm ==2.5.*
-    , text ==1.2.*
-    , text-show >=3.7 && <3.10
-    , time >=1.8 && <1.13
-    , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
-    , vector >=0.12 && <0.14
-    , wreq >=0.5.2 && <0.6
-  default-language: Haskell2010
-
 executable tutorial
   main-is: Main.hs
   other-modules:
@@ -388,6 +261,7 @@ executable tutorial
     , bytestring-to-vector ==0.3.*
     , containers >=0.5.11 && <0.7
     , data-default >=0.5 && <0.8
+    , ekg
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
     , formatting >=6.0 && <8.0
@@ -400,94 +274,6 @@ executable tutorial
     , random >=1.1 && <1.3
     , safe ==0.3.*
     , sdl2 >=2.4.0 && <2.6
-    , stm ==2.5.*
-    , text ==1.2.*
-    , text-show >=3.7 && <3.10
-    , time >=1.8 && <1.13
-    , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
-    , vector >=0.12 && <0.14
-    , wreq >=0.5.2 && <0.6
-  default-language: Haskell2010
-
-test-suite monomer-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Monomer.Common.CursorIconSpec
-      Monomer.Graphics.UtilSpec
-      Monomer.TestEventUtil
-      Monomer.TestUtil
-      Monomer.Widgets.Animation.FadeSpec
-      Monomer.Widgets.Animation.SlideSpec
-      Monomer.Widgets.CompositeSpec
-      Monomer.Widgets.Containers.AlertSpec
-      Monomer.Widgets.Containers.BoxSpec
-      Monomer.Widgets.Containers.ConfirmSpec
-      Monomer.Widgets.Containers.DragDropSpec
-      Monomer.Widgets.Containers.DropdownSpec
-      Monomer.Widgets.Containers.GridSpec
-      Monomer.Widgets.Containers.KeystrokeSpec
-      Monomer.Widgets.Containers.ScrollSpec
-      Monomer.Widgets.Containers.SelectListSpec
-      Monomer.Widgets.Containers.SplitSpec
-      Monomer.Widgets.Containers.StackSpec
-      Monomer.Widgets.Containers.ThemeSwitchSpec
-      Monomer.Widgets.Containers.TooltipSpec
-      Monomer.Widgets.Containers.ZStackSpec
-      Monomer.Widgets.ContainerSpec
-      Monomer.Widgets.Singles.ButtonSpec
-      Monomer.Widgets.Singles.CheckboxSpec
-      Monomer.Widgets.Singles.ColorPickerSpec
-      Monomer.Widgets.Singles.DateFieldSpec
-      Monomer.Widgets.Singles.DialSpec
-      Monomer.Widgets.Singles.ExternalLinkSpec
-      Monomer.Widgets.Singles.ImageSpec
-      Monomer.Widgets.Singles.LabeledCheckboxSpec
-      Monomer.Widgets.Singles.LabeledRadioSpec
-      Monomer.Widgets.Singles.LabelSpec
-      Monomer.Widgets.Singles.NumericFieldSpec
-      Monomer.Widgets.Singles.RadioSpec
-      Monomer.Widgets.Singles.SeparatorLineSpec
-      Monomer.Widgets.Singles.SliderSpec
-      Monomer.Widgets.Singles.SpacerSpec
-      Monomer.Widgets.Singles.TextAreaSpec
-      Monomer.Widgets.Singles.TextFieldSpec
-      Monomer.Widgets.Singles.TimeFieldSpec
-      Monomer.Widgets.Util.FocusSpec
-      Monomer.Widgets.Util.StyleSpec
-      Monomer.Widgets.Util.TextSpec
-      Paths_monomer
-  hs-source-dirs:
-      test/unit
-  default-extensions:
-      OverloadedStrings
-  ghc-options: -threaded -fwarn-incomplete-patterns
-  build-depends:
-      HUnit ==1.6.*
-    , JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
-    , async >=2.1 && <2.3
-    , attoparsec >=0.12 && <0.15
-    , base >=4.11 && <5
-    , bytestring >=0.10 && <0.12
-    , bytestring-to-vector ==0.3.*
-    , containers >=0.5.11 && <0.7
-    , data-default >=0.5 && <0.8
-    , directory ==1.3.*
-    , exceptions ==0.10.*
-    , extra >=1.6 && <1.9
-    , formatting >=6.0 && <8.0
-    , hspec >=2.4 && <3.0
-    , http-client >=0.6 && <0.9
-    , lens >=4.16 && <5.1
-    , monomer
-    , mtl >=2.1 && <2.3
-    , nanovg >=0.8 && <1.0
-    , process ==1.6.*
-    , safe ==0.3.*
-    , sdl2 >=2.4.0 && <2.6
-    , silently ==1.2.*
     , stm ==2.5.*
     , text ==1.2.*
     , text-show >=3.7 && <3.10

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -188,6 +188,92 @@ library
         GLEW
   default-language: Haskell2010
 
+executable books
+  main-is: Main.hs
+  other-modules:
+      BookTypes
+      Paths_monomer
+  hs-source-dirs:
+      examples/books
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -threaded
+  build-depends:
+      JuicyPixels >=3.2.9 && <3.5
+    , OpenGL ==3.0.*
+    , aeson >=1.4 && <1.6
+    , async >=2.1 && <2.3
+    , attoparsec >=0.12 && <0.15
+    , base >=4.11 && <5
+    , bytestring >=0.10 && <0.12
+    , bytestring-to-vector ==0.3.*
+    , containers >=0.5.11 && <0.7
+    , data-default >=0.5 && <0.8
+    , exceptions ==0.10.*
+    , extra >=1.6 && <1.9
+    , formatting >=6.0 && <8.0
+    , http-client >=0.6 && <0.9
+    , lens >=4.16 && <5.1
+    , monomer
+    , mtl >=2.1 && <2.3
+    , nanovg >=0.8 && <1.0
+    , process ==1.6.*
+    , safe ==0.3.*
+    , sdl2 >=2.4.0 && <2.6
+    , stm ==2.5.*
+    , text ==1.2.*
+    , text-show >=3.7 && <3.10
+    , time >=1.8 && <1.13
+    , transformers >=0.5 && <0.7
+    , unordered-containers >=0.2.8 && <0.3
+    , vector >=0.12 && <0.14
+    , wreq >=0.5.2 && <0.6
+  default-language: Haskell2010
+
+executable generative
+  main-is: Main.hs
+  other-modules:
+      GenerativeTypes
+      Widgets.BoxesPalette
+      Widgets.CirclesGrid
+      Paths_monomer
+  hs-source-dirs:
+      examples/generative
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -threaded
+  build-depends:
+      JuicyPixels >=3.2.9 && <3.5
+    , OpenGL ==3.0.*
+    , async >=2.1 && <2.3
+    , attoparsec >=0.12 && <0.15
+    , base >=4.11 && <5
+    , bytestring >=0.10 && <0.12
+    , bytestring-to-vector ==0.3.*
+    , containers >=0.5.11 && <0.7
+    , data-default >=0.5 && <0.8
+    , exceptions ==0.10.*
+    , extra >=1.6 && <1.9
+    , formatting >=6.0 && <8.0
+    , http-client >=0.6 && <0.9
+    , lens >=4.16 && <5.1
+    , monomer
+    , mtl >=2.1 && <2.3
+    , nanovg >=0.8 && <1.0
+    , process ==1.6.*
+    , random >=1.1 && <1.3
+    , safe ==0.3.*
+    , sdl2 >=2.4.0 && <2.6
+    , stm ==2.5.*
+    , text ==1.2.*
+    , text-show >=3.7 && <3.10
+    , time >=1.8 && <1.13
+    , transformers >=0.5 && <0.7
+    , unordered-containers >=0.2.8 && <0.3
+    , vector >=0.12 && <0.14
+    , wreq >=0.5.2 && <0.6
+  default-language: Haskell2010
+
 executable ticker
   main-is: Main.hs
   other-modules:
@@ -234,6 +320,47 @@ executable ticker
     , wuss ==1.1.*
   default-language: Haskell2010
 
+executable todo
+  main-is: Main.hs
+  other-modules:
+      TodoTypes
+      Paths_monomer
+  hs-source-dirs:
+      examples/todo
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -threaded
+  build-depends:
+      JuicyPixels >=3.2.9 && <3.5
+    , OpenGL ==3.0.*
+    , async >=2.1 && <2.3
+    , attoparsec >=0.12 && <0.15
+    , base >=4.11 && <5
+    , bytestring >=0.10 && <0.12
+    , bytestring-to-vector ==0.3.*
+    , containers >=0.5.11 && <0.7
+    , data-default >=0.5 && <0.8
+    , exceptions ==0.10.*
+    , extra >=1.6 && <1.9
+    , formatting >=6.0 && <8.0
+    , http-client >=0.6 && <0.9
+    , lens >=4.16 && <5.1
+    , monomer
+    , mtl >=2.1 && <2.3
+    , nanovg >=0.8 && <1.0
+    , process ==1.6.*
+    , safe ==0.3.*
+    , sdl2 >=2.4.0 && <2.6
+    , stm ==2.5.*
+    , text ==1.2.*
+    , text-show >=3.7 && <3.10
+    , time >=1.8 && <1.13
+    , transformers >=0.5 && <0.7
+    , unordered-containers >=0.2.8 && <0.3
+    , vector >=0.12 && <0.14
+    , wreq >=0.5.2 && <0.6
+  default-language: Haskell2010
+
 executable tutorial
   main-is: Main.hs
   other-modules:
@@ -261,7 +388,6 @@ executable tutorial
     , bytestring-to-vector ==0.3.*
     , containers >=0.5.11 && <0.7
     , data-default >=0.5 && <0.8
-    , ekg
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
     , formatting >=6.0 && <8.0
@@ -274,6 +400,94 @@ executable tutorial
     , random >=1.1 && <1.3
     , safe ==0.3.*
     , sdl2 >=2.4.0 && <2.6
+    , stm ==2.5.*
+    , text ==1.2.*
+    , text-show >=3.7 && <3.10
+    , time >=1.8 && <1.13
+    , transformers >=0.5 && <0.7
+    , unordered-containers >=0.2.8 && <0.3
+    , vector >=0.12 && <0.14
+    , wreq >=0.5.2 && <0.6
+  default-language: Haskell2010
+
+test-suite monomer-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Monomer.Common.CursorIconSpec
+      Monomer.Graphics.UtilSpec
+      Monomer.TestEventUtil
+      Monomer.TestUtil
+      Monomer.Widgets.Animation.FadeSpec
+      Monomer.Widgets.Animation.SlideSpec
+      Monomer.Widgets.CompositeSpec
+      Monomer.Widgets.Containers.AlertSpec
+      Monomer.Widgets.Containers.BoxSpec
+      Monomer.Widgets.Containers.ConfirmSpec
+      Monomer.Widgets.Containers.DragDropSpec
+      Monomer.Widgets.Containers.DropdownSpec
+      Monomer.Widgets.Containers.GridSpec
+      Monomer.Widgets.Containers.KeystrokeSpec
+      Monomer.Widgets.Containers.ScrollSpec
+      Monomer.Widgets.Containers.SelectListSpec
+      Monomer.Widgets.Containers.SplitSpec
+      Monomer.Widgets.Containers.StackSpec
+      Monomer.Widgets.Containers.ThemeSwitchSpec
+      Monomer.Widgets.Containers.TooltipSpec
+      Monomer.Widgets.Containers.ZStackSpec
+      Monomer.Widgets.ContainerSpec
+      Monomer.Widgets.Singles.ButtonSpec
+      Monomer.Widgets.Singles.CheckboxSpec
+      Monomer.Widgets.Singles.ColorPickerSpec
+      Monomer.Widgets.Singles.DateFieldSpec
+      Monomer.Widgets.Singles.DialSpec
+      Monomer.Widgets.Singles.ExternalLinkSpec
+      Monomer.Widgets.Singles.ImageSpec
+      Monomer.Widgets.Singles.LabeledCheckboxSpec
+      Monomer.Widgets.Singles.LabeledRadioSpec
+      Monomer.Widgets.Singles.LabelSpec
+      Monomer.Widgets.Singles.NumericFieldSpec
+      Monomer.Widgets.Singles.RadioSpec
+      Monomer.Widgets.Singles.SeparatorLineSpec
+      Monomer.Widgets.Singles.SliderSpec
+      Monomer.Widgets.Singles.SpacerSpec
+      Monomer.Widgets.Singles.TextAreaSpec
+      Monomer.Widgets.Singles.TextFieldSpec
+      Monomer.Widgets.Singles.TimeFieldSpec
+      Monomer.Widgets.Util.FocusSpec
+      Monomer.Widgets.Util.StyleSpec
+      Monomer.Widgets.Util.TextSpec
+      Paths_monomer
+  hs-source-dirs:
+      test/unit
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -threaded -fwarn-incomplete-patterns
+  build-depends:
+      HUnit ==1.6.*
+    , JuicyPixels >=3.2.9 && <3.5
+    , OpenGL ==3.0.*
+    , async >=2.1 && <2.3
+    , attoparsec >=0.12 && <0.15
+    , base >=4.11 && <5
+    , bytestring >=0.10 && <0.12
+    , bytestring-to-vector ==0.3.*
+    , containers >=0.5.11 && <0.7
+    , data-default >=0.5 && <0.8
+    , directory ==1.3.*
+    , exceptions ==0.10.*
+    , extra >=1.6 && <1.9
+    , formatting >=6.0 && <8.0
+    , hspec >=2.4 && <3.0
+    , http-client >=0.6 && <0.9
+    , lens >=4.16 && <5.1
+    , monomer
+    , mtl >=2.1 && <2.3
+    , nanovg >=0.8 && <1.0
+    , process ==1.6.*
+    , safe ==0.3.*
+    , sdl2 >=2.4.0 && <2.6
+    , silently ==1.2.*
     , stm ==2.5.*
     , text ==1.2.*
     , text-show >=3.7 && <3.10

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           monomer
-version:        1.0.0.2
+version:        1.0.0.3
 synopsis:       A GUI library for writing native Haskell applications.
 description:    Monomer is an easy to use, cross platform, GUI library for writing native
                 Haskell applications.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: monomer
-version: 1.0.0.2
+version: 1.0.0.3
 github: fjvallarino/monomer
 license: BSD3
 author: Francisco Vallarino

--- a/package.yaml
+++ b/package.yaml
@@ -76,28 +76,6 @@ library:
         extra-libraries: GLEW
 
 executables:
-  todo:
-    main: Main.hs
-    source-dirs: examples/todo
-    ghc-options:
-    - -threaded
-    dependencies:
-    - lens >= 4.16 && < 5.1
-    - monomer
-    - text-show >= 3.7 && < 3.10
-
-  books:
-    main: Main.hs
-    source-dirs: examples/books
-    ghc-options:
-    - -threaded
-    dependencies:
-    - aeson >= 1.4 && < 1.6
-    - lens >= 4.16 && < 5.1
-    - monomer
-    - text-show >= 3.7 && < 3.10
-    - wreq >= 0.5.2 && < 0.6
-
   ticker:
     main: Main.hs
     source-dirs: examples/ticker
@@ -112,39 +90,15 @@ executables:
     - websockets >= 0.12 && < 0.13
     - wuss >= 1.1 && < 1.2
 
-  generative:
-    main: Main.hs
-    source-dirs: examples/generative
-    ghc-options:
-    - -threaded
-    dependencies:
-    - lens >= 4.16 && < 5.1
-    - monomer
-    - random >= 1.1 && < 1.3
-    - text-show >= 3.7 && < 3.10
-
   tutorial:
     main: Main.hs
     source-dirs: examples/tutorial
     ghc-options:
     - -threaded
     dependencies:
+    - ekg
     - lens >= 4.16 && < 5.1
     - monomer
     - random >= 1.1 && < 1.3
     - text-show >= 3.7 && < 3.10
     - time >= 1.8 && < 1.13
-
-tests:
-  monomer-test:
-    main: Spec.hs
-    source-dirs: test/unit
-    ghc-options:
-    - -threaded
-    - -fwarn-incomplete-patterns
-    dependencies:
-    - directory >= 1.3 && < 1.4
-    - monomer
-    - hspec >= 2.4 && < 3.0
-    - HUnit >= 1.6 && < 1.7
-    - silently >= 1.2 && < 1.3

--- a/package.yaml
+++ b/package.yaml
@@ -7,8 +7,8 @@ maintainer: fjvallarino@gmail.com
 copyright: 2018 Francisco Vallarino
 
 extra-source-files:
-- README.md
-- ChangeLog.md
+  - README.md
+  - ChangeLog.md
 
 # Metadata used when publishing your package
 synopsis: A GUI library for writing native Haskell applications.
@@ -23,51 +23,51 @@ description: |
   Please see the README on Github at <https://github.com/fjvallarino/monomer#readme>
 
 default-extensions:
-- OverloadedStrings
+  - OverloadedStrings
 
 dependencies:
-- async >= 2.1 && < 2.3
-- attoparsec >= 0.12 && < 0.15
-- base >= 4.11 && < 5
-- bytestring >= 0.10 && < 0.12
-- bytestring-to-vector >= 0.3 && < 0.4
-- containers >= 0.5.11 && < 0.7
-- data-default >= 0.5 && < 0.8
-- exceptions >= 0.10 && < 0.11
-- extra >= 1.6 && < 1.9
-- formatting >= 6.0 && < 8.0
-- http-client >= 0.6 && < 0.9
-- JuicyPixels >= 3.2.9 && < 3.5
-- lens >= 4.16 && < 5.1
-- mtl >= 2.1 && < 2.3
-- nanovg >= 0.8 && < 1.0
-- OpenGL >= 3.0 && < 3.1
-- process >= 1.6 && < 1.7
-- safe >= 0.3 && < 0.4
-- sdl2 >= 2.4.0 && < 2.6
-- stm >= 2.5 && < 2.6
-- text >= 1.2 && < 1.3
-- text-show >= 3.7 && < 3.10
-- time >= 1.8 && < 1.13
-- transformers >= 0.5 && < 0.7
-- unordered-containers >= 0.2.8 && < 0.3
-- vector >= 0.12 && < 0.14
-- wreq >= 0.5.2 && < 0.6
+  - async >= 2.1 && < 2.3
+  - attoparsec >= 0.12 && < 0.15
+  - base >= 4.11 && < 5
+  - bytestring >= 0.10 && < 0.12
+  - bytestring-to-vector >= 0.3 && < 0.4
+  - containers >= 0.5.11 && < 0.7
+  - data-default >= 0.5 && < 0.8
+  - exceptions >= 0.10 && < 0.11
+  - extra >= 1.6 && < 1.9
+  - formatting >= 6.0 && < 8.0
+  - http-client >= 0.6 && < 0.9
+  - JuicyPixels >= 3.2.9 && < 3.5
+  - lens >= 4.16 && < 5.1
+  - mtl >= 2.1 && < 2.3
+  - nanovg >= 0.8 && < 1.0
+  - OpenGL >= 3.0 && < 3.1
+  - process >= 1.6 && < 1.7
+  - safe >= 0.3 && < 0.4
+  - sdl2 >= 2.4.0 && < 2.6
+  - stm >= 2.5 && < 2.6
+  - text >= 1.2 && < 1.3
+  - text-show >= 3.7 && < 3.10
+  - time >= 1.8 && < 1.13
+  - transformers >= 0.5 && < 0.7
+  - unordered-containers >= 0.2.8 && < 0.3
+  - vector >= 0.12 && < 0.14
+  - wreq >= 0.5.2 && < 0.6
 
 library:
   source-dirs: src
   include-dirs: cbits
   install-includes:
-  - fontmanager.h
+    - fontmanager.h
   c-sources:
-  - cbits/dpi.c
-  - cbits/fontmanager.c
-  - cbits/glew.c
+    - cbits/dpi.c
+    - cbits/fontmanager.c
+    - cbits/glew.c
   build-tools: c2hs
   cc-options:
-  - -fPIC
+    - -fPIC
   ghc-options:
-  - -fwarn-incomplete-patterns
+    - -fwarn-incomplete-patterns
   when:
     - condition: os(windows)
       then:
@@ -76,29 +76,75 @@ library:
         extra-libraries: GLEW
 
 executables:
+  todo:
+    main: Main.hs
+    source-dirs: examples/todo
+    ghc-options:
+      - -threaded
+    dependencies:
+      - lens >= 4.16 && < 5.1
+      - monomer
+      - text-show >= 3.7 && < 3.10
+
+  books:
+    main: Main.hs
+    source-dirs: examples/books
+    ghc-options:
+      - -threaded
+    dependencies:
+      - aeson >= 1.4 && < 1.6
+      - lens >= 4.16 && < 5.1
+      - monomer
+      - text-show >= 3.7 && < 3.10
+      - wreq >= 0.5.2 && < 0.6
+
   ticker:
     main: Main.hs
     source-dirs: examples/ticker
     ghc-options:
-    - -threaded
+      - -threaded
     dependencies:
-    - aeson >= 1.4 && < 1.6
-    - lens >= 4.16 && < 5.1
-    - monomer
-    - scientific >= 0.3 && < 0.4
-    - text-show >= 3.7 && < 3.10
-    - websockets >= 0.12 && < 0.13
-    - wuss >= 1.1 && < 1.2
+      - aeson >= 1.4 && < 1.6
+      - lens >= 4.16 && < 5.1
+      - monomer
+      - scientific >= 0.3 && < 0.4
+      - text-show >= 3.7 && < 3.10
+      - websockets >= 0.12 && < 0.13
+      - wuss >= 1.1 && < 1.2
+
+  generative:
+    main: Main.hs
+    source-dirs: examples/generative
+    ghc-options:
+      - -threaded
+    dependencies:
+      - lens >= 4.16 && < 5.1
+      - monomer
+      - random >= 1.1 && < 1.3
+      - text-show >= 3.7 && < 3.10
 
   tutorial:
     main: Main.hs
     source-dirs: examples/tutorial
     ghc-options:
-    - -threaded
+      - -threaded
     dependencies:
-    - ekg
-    - lens >= 4.16 && < 5.1
-    - monomer
-    - random >= 1.1 && < 1.3
-    - text-show >= 3.7 && < 3.10
-    - time >= 1.8 && < 1.13
+      - lens >= 4.16 && < 5.1
+      - monomer
+      - random >= 1.1 && < 1.3
+      - text-show >= 3.7 && < 3.10
+      - time >= 1.8 && < 1.13
+
+tests:
+  monomer-test:
+    main: Spec.hs
+    source-dirs: test/unit
+    ghc-options:
+      - -threaded
+      - -fwarn-incomplete-patterns
+    dependencies:
+      - directory >= 1.3 && < 1.4
+      - monomer
+      - hspec >= 2.4 && < 3.0
+      - HUnit >= 1.6 && < 1.7
+      - silently >= 1.2 && < 1.3

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Helper functions creating, validating and merging size requirements.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Core.SizeReq (

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Helper functions creating, validating and merging size requirements.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Core.SizeReq (
   SizeReqUpdater(..),
   clearExtra,

--- a/src/Monomer/Core/Style.hs
+++ b/src/Monomer/Core/Style.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Helper functions for creating style configurations, and corresponding instances.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Core.Style (

--- a/src/Monomer/Core/Style.hs
+++ b/src/Monomer/Core/Style.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Helper functions for creating style configurations, and corresponding instances.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Core.Style (
   module Monomer.Core.StyleTypes,
   module Monomer.Core.ThemeTypes,

--- a/src/Monomer/Core/StyleTypes.hs
+++ b/src/Monomer/Core/StyleTypes.hs
@@ -9,8 +9,7 @@ Portability : non-portable
 Basic types for styling widgets.
 -}
 {-# LANGUAGE DeriveGeneric #-}
-
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Core.StyleTypes where
 

--- a/src/Monomer/Core/StyleTypes.hs
+++ b/src/Monomer/Core/StyleTypes.hs
@@ -10,6 +10,8 @@ Basic types for styling widgets.
 -}
 {-# LANGUAGE DeriveGeneric #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Core.StyleTypes where
 
 import Control.Applicative ((<|>))

--- a/src/Monomer/Core/StyleUtil.hs
+++ b/src/Monomer/Core/StyleUtil.hs
@@ -10,6 +10,7 @@ Helper functions for style types.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Core.StyleUtil (
   getContentArea,

--- a/src/Monomer/Core/ThemeTypes.hs
+++ b/src/Monomer/Core/ThemeTypes.hs
@@ -10,6 +10,8 @@ Theme configuration types.
 -}
 {-# LANGUAGE DeriveGeneric #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Core.ThemeTypes where
 
 import Control.Applicative ((<|>))

--- a/src/Monomer/Core/ThemeTypes.hs
+++ b/src/Monomer/Core/ThemeTypes.hs
@@ -9,7 +9,6 @@ Portability : non-portable
 Theme configuration types.
 -}
 {-# LANGUAGE DeriveGeneric #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Core.ThemeTypes where

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -12,7 +12,6 @@ Basic types and definitions for Widgets.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Core.WidgetTypes where
@@ -344,31 +343,31 @@ data WidgetEnv s e = WidgetEnv {
 data WidgetNodeInfo =
   WidgetNodeInfo {
     -- | Type of the widget.
-    _wniWidgetType :: !WidgetType,
+    _wniWidgetType :: WidgetType,
     -- | The identifier at creation time of the widget (runtime generated).
-    _wniWidgetId :: !WidgetId,
+    _wniWidgetId :: WidgetId,
     -- | Key/Identifier of the widget (user provided). Used for merging.
     _wniKey :: Maybe WidgetKey,
     -- | The path of the instance in the widget tree, as a set of indexes.
-    _wniPath :: !Path,
+    _wniPath :: Path,
     -- | The requested width for the widget. The one in style takes precedence.
-    _wniSizeReqW :: !SizeReq,
+    _wniSizeReqW :: SizeReq,
     -- | The requested height for the widget. The one in style takes precedence.
-    _wniSizeReqH :: !SizeReq,
+    _wniSizeReqH :: SizeReq,
     -- | Indicates if the widget is enabled for user interaction.
-    _wniEnabled :: !Bool,
+    _wniEnabled :: Bool,
     -- | Indicates if the widget is visible.
-    _wniVisible :: !Bool,
+    _wniVisible :: Bool,
     -- | Indicates whether the widget can receive focus.
-    _wniFocusable :: !Bool,
+    _wniFocusable :: Bool,
     {-|
     The area of the window where the widget can draw. Could be out of bounds or
     partially invisible if inside a scroll. The viewport on 'WidgetEnv' defines
     what is currently visible.
     -}
-    _wniViewport :: !Rect,
+    _wniViewport :: Rect,
     -- | Style attributes of the widget instance.
-    _wniStyle :: !Style
+    _wniStyle :: Style
   } deriving (Eq, Show, Generic)
 
 instance Default WidgetNodeInfo where
@@ -389,11 +388,11 @@ instance Default WidgetNodeInfo where
 -- | An instance of the widget in the widget tree.
 data WidgetNode s e = WidgetNode {
   -- | The actual widget.
-  _wnWidget :: !(Widget s e),
+  _wnWidget :: Widget s e,
   -- | Information about the instance.
-  _wnInfo :: !WidgetNodeInfo,
+  _wnInfo :: WidgetNodeInfo,
   -- | The children widgets, if any.
-  _wnChildren :: !(Seq (WidgetNode s e))
+  _wnChildren :: Seq (WidgetNode s e)
 }
 
 {-|

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -13,6 +13,8 @@ Basic types and definitions for Widgets.
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Core.WidgetTypes where
 
 import Control.Concurrent (MVar)
@@ -366,7 +368,7 @@ data WidgetNodeInfo =
     -}
     _wniViewport :: !Rect,
     -- | Style attributes of the widget instance.
-    _wniStyle :: Style
+    _wniStyle :: !Style
   } deriving (Eq, Show, Generic)
 
 instance Default WidgetNodeInfo where
@@ -387,11 +389,11 @@ instance Default WidgetNodeInfo where
 -- | An instance of the widget in the widget tree.
 data WidgetNode s e = WidgetNode {
   -- | The actual widget.
-  _wnWidget :: Widget s e,
+  _wnWidget :: !(Widget s e),
   -- | Information about the instance.
-  _wnInfo :: WidgetNodeInfo,
+  _wnInfo :: !WidgetNodeInfo,
   -- | The children widgets, if any.
-  _wnChildren :: Seq (WidgetNode s e)
+  _wnChildren :: !(Seq (WidgetNode s e))
 }
 
 {-|

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -9,6 +9,7 @@ Portability : non-portable
 Provides functions for getting text dimensions and metrics.
 -}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Graphics.FontManager (
   makeFontManager

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -11,6 +11,7 @@ Renderer based on the nanovg library.
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TupleSections #-}
 
 module Monomer.Graphics.NanoVGRenderer (makeRenderer) where

--- a/src/Monomer/Graphics/Text.hs
+++ b/src/Monomer/Graphics/Text.hs
@@ -11,7 +11,6 @@ Helper functions for calculating text size.
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Graphics.Text (

--- a/src/Monomer/Graphics/Text.hs
+++ b/src/Monomer/Graphics/Text.hs
@@ -12,6 +12,8 @@ Helper functions for calculating text size.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Graphics.Text (
   calcTextSize,
   calcTextSize_,
@@ -193,7 +195,7 @@ getTextLinesSize textLines = size where
   spaceV = unFontSpace $ maybe def _tlFontSpaceV (textLines ^? ix 0)
   lineW line = line ^. L.size . L.w
   lineH line = line ^. L.size . L.h + unFontSpace (_tlFontSpaceV line)
-  width = maximum (fmap lineW textLines)
+  ~width = maximum (fmap lineW textLines)
   height = sum (fmap lineH textLines) - spaceV
   size
     | Seq.null textLines = def

--- a/src/Monomer/Graphics/Types.hs
+++ b/src/Monomer/Graphics/Types.hs
@@ -11,6 +11,7 @@ Basic types for Graphics.
 Angles are always expressed in degrees, not radians.
 -}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Graphics.Types where
 

--- a/src/Monomer/Graphics/Util.hs
+++ b/src/Monomer/Graphics/Util.hs
@@ -8,6 +8,8 @@ Portability : non-portable
 
 Helper functions for graphics related operations.
 -}
+{-# LANGUAGE Strict #-}
+
 module Monomer.Graphics.Util (
   clampChannel,
   clampAlpha,
@@ -59,14 +61,17 @@ rgba r g b a = Color {
 -- | Creates a Color from a hex string. It may include a # prefix or not.
 rgbHex :: String -> Color
 rgbHex hex
-  | length hex == 7 = rgbHex (tail hex)
-  | length hex == 6 = rgb r g b
+  | length hex == 7 = rgbHexSix (tail hex)
+  | length hex == 6 = rgbHexSix hex
   | otherwise = rgb 0 0 0
-  where
-    [r1, r2, g1, g2, b1, b2] = hex
-    r = digitToInt r1 * 16 + digitToInt r2
-    g = digitToInt g1 * 16 + digitToInt g2
-    b = digitToInt b1 * 16 + digitToInt b2
+
+-- | Creates a color from a six characters hex string. Fails if len is invalid.
+rgbHexSix :: [Char] -> Color
+rgbHexSix hex = rgb r g b where
+  [r1, r2, g1, g2, b1, b2] = hex
+  r = digitToInt r1 * 16 + digitToInt r2
+  g = digitToInt g1 * 16 + digitToInt g2
+  b = digitToInt b1 * 16 + digitToInt b2
 
 {-|
 Creates a Color from a hex string plus an alpha component. It may include a #

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Core glue for running an application.
 -}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE Strict #-}
@@ -73,22 +72,22 @@ data MainLoopArgs sp e ep = MainLoopArgs {
   _mlOS :: Text,
   _mlRenderer :: Maybe Renderer,
   _mlTheme :: Theme,
-  _mlAppStartTs :: !Int,
-  _mlMaxFps :: !Int,
-  _mlLatestRenderTs :: !Int,
-  _mlFrameStartTs :: !Int,
-  _mlFrameAccumTs :: !Int,
-  _mlFrameCount :: !Int,
+  _mlAppStartTs :: Int,
+  _mlMaxFps :: Int,
+  _mlLatestRenderTs :: Int,
+  _mlFrameStartTs :: Int,
+  _mlFrameAccumTs :: Int,
+  _mlFrameCount :: Int,
   _mlExitEvents :: [e],
-  _mlWidgetRoot :: !(WidgetNode sp ep),
+  _mlWidgetRoot :: WidgetNode sp ep,
   _mlWidgetShared :: MVar (Map Text WidgetShared),
   _mlChannel :: TChan (RenderMsg sp ep)
 }
 
 data RenderState s e = RenderState {
-  _rstDpr :: !Double,
-  _rstWidgetEnv :: !(WidgetEnv s e),
-  _rstRootNode :: !(WidgetNode s e)
+  _rstDpr :: Double,
+  _rstWidgetEnv :: WidgetEnv s e,
+  _rstRootNode :: WidgetNode s e
 }
 
 {-|

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -11,7 +11,6 @@ Core glue for running an application.
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Main.Core (
@@ -145,7 +144,7 @@ runAppLoop window glCtx channel widgetRoot config = do
 
   startTs <- fmap fromIntegral SDL.ticks
   model <- use L.mainModel
-  os <- getPlatform
+  os <- liftIO getPlatform
   widgetSharedMVar <- liftIO $ newMVar Map.empty
   renderer <- if useRenderThread
     then return Nothing
@@ -233,8 +232,8 @@ mainLoop window fontManager config loopArgs = do
   dragged <- getDraggedMsgInfo
   mainPress <- use L.mainBtnPress
   inputStatus <- use L.inputStatus
-  mousePos <- getCurrentMousePos epr
-  currWinSize <- getViewportSize window dpr
+  mousePos <- liftIO $ getCurrentMousePos epr
+  currWinSize <- liftIO $ getViewportSize window dpr
 
   let Size rw rh = windowSize
   let ts = startTicks - _mlFrameStartTs
@@ -291,11 +290,11 @@ mainLoop window fontManager config loopArgs = do
         | otherwise = Seq.Empty
   let baseStep = (wenv, _mlWidgetRoot, Seq.empty)
 
-  (!rqWenv, !rqRoot, _) <- handleRequests baseReqs baseStep
-  (!wtWenv, !wtRoot, _) <- handleWidgetTasks rqWenv rqRoot
-  (!seWenv, !seRoot, _) <- handleSystemEvents wtWenv wtRoot baseSystemEvents
+  (rqWenv, rqRoot, _) <- handleRequests baseReqs baseStep
+  (wtWenv, wtRoot, _) <- handleWidgetTasks rqWenv rqRoot
+  (seWenv, seRoot, _) <- handleSystemEvents wtWenv wtRoot baseSystemEvents
 
-  (!newWenv, !newRoot, _) <- if windowResized
+  (newWenv, newRoot, _) <- if windowResized
     then do
       L.windowSize .= currWinSize
       handleResizeWidgets (seWenv, seRoot, Seq.empty)
@@ -421,29 +420,29 @@ renderWidgets
   -> WidgetEnv s e
   -> WidgetNode s e
   -> IO ()
-renderWidgets !window dpr renderer clearColor wenv widgetRoot = do
+renderWidgets window dpr renderer clearColor wenv widgetRoot = do
   Size dwW dwH <- getDrawableSize window
   Size vpW vpH <- getViewportSize window dpr
 
   let position = GL.Position 0 0
   let size = GL.Size (round dwW) (round dwH)
 
-  liftIO $ GL.viewport GL.$= (position, size)
+  GL.viewport GL.$= (position, size)
 
-  liftIO $ GL.clearColor GL.$= clearColor4
-  liftIO $ GL.clear [GL.ColorBuffer]
+  GL.clearColor GL.$= clearColor4
+  GL.clear [GL.ColorBuffer]
 
-  liftIO $ beginFrame renderer vpW vpH
-  liftIO $ widgetRender (widgetRoot ^. L.widget) wenv widgetRoot renderer
-  liftIO $ endFrame renderer
+  beginFrame renderer vpW vpH
+  widgetRender (widgetRoot ^. L.widget) wenv widgetRoot renderer
+  endFrame renderer
 
-  liftIO $ renderRawTasks renderer
+  renderRawTasks renderer
 
-  liftIO $ beginFrame renderer vpW vpH
-  liftIO $ renderOverlays renderer
-  liftIO $ endFrame renderer
+  beginFrame renderer vpW vpH
+  renderOverlays renderer
+  endFrame renderer
 
-  liftIO $ renderRawOverlays renderer
+  renderRawOverlays renderer
 
   SDL.glSwapWindow window
   where

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -12,6 +12,8 @@ Core glue for running an application.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.Core (
   AppEventResponse(..),
   AppEventHandler(..),
@@ -72,22 +74,22 @@ data MainLoopArgs sp e ep = MainLoopArgs {
   _mlOS :: Text,
   _mlRenderer :: Maybe Renderer,
   _mlTheme :: Theme,
-  _mlAppStartTs :: Int,
-  _mlMaxFps :: Int,
-  _mlLatestRenderTs :: Int,
-  _mlFrameStartTs :: Int,
-  _mlFrameAccumTs :: Int,
-  _mlFrameCount :: Int,
+  _mlAppStartTs :: !Int,
+  _mlMaxFps :: !Int,
+  _mlLatestRenderTs :: !Int,
+  _mlFrameStartTs :: !Int,
+  _mlFrameAccumTs :: !Int,
+  _mlFrameCount :: !Int,
   _mlExitEvents :: [e],
-  _mlWidgetRoot :: WidgetNode sp ep,
+  _mlWidgetRoot :: !(WidgetNode sp ep),
   _mlWidgetShared :: MVar (Map Text WidgetShared),
   _mlChannel :: TChan (RenderMsg sp ep)
 }
 
 data RenderState s e = RenderState {
-  _rstDpr :: Double,
-  _rstWidgetEnv :: WidgetEnv s e,
-  _rstRootNode :: WidgetNode s e
+  _rstDpr :: !Double,
+  _rstWidgetEnv :: !(WidgetEnv s e),
+  _rstRootNode :: !(WidgetNode s e)
 }
 
 {-|
@@ -289,11 +291,11 @@ mainLoop window fontManager config loopArgs = do
         | otherwise = Seq.Empty
   let baseStep = (wenv, _mlWidgetRoot, Seq.empty)
 
-  (rqWenv, rqRoot, _) <- handleRequests baseReqs baseStep
-  (wtWenv, wtRoot, _) <- handleWidgetTasks rqWenv rqRoot
-  (seWenv, seRoot, _) <- handleSystemEvents wtWenv wtRoot baseSystemEvents
+  (!rqWenv, !rqRoot, _) <- handleRequests baseReqs baseStep
+  (!wtWenv, !wtRoot, _) <- handleWidgetTasks rqWenv rqRoot
+  (!seWenv, !seRoot, _) <- handleSystemEvents wtWenv wtRoot baseSystemEvents
 
-  (newWenv, newRoot, _) <- if windowResized
+  (!newWenv, !newRoot, _) <- if windowResized
     then do
       L.windowSize .= currWinSize
       handleResizeWidgets (seWenv, seRoot, Seq.empty)

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -13,6 +13,8 @@ overlays and all SystemEvent related operations and updates.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.Handlers (
   HandlerStep,
   handleSystemEvents,

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -12,7 +12,6 @@ overlays and all SystemEvent related operations and updates.
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Main.Handlers (

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -8,6 +8,8 @@ Portability : non-portable
 
 Helper functions for SDL platform related operations.
 -}
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.Platform (
   defaultWindowSize,
   initSDLWindow,
@@ -138,20 +140,20 @@ detroySDLWindow window = do
   SDL.quit
 
 -- | Returns the current mouse position.
-getCurrentMousePos :: (MonadIO m) => Double -> m Point
+getCurrentMousePos :: Double -> IO Point
 getCurrentMousePos epr = do
   SDL.P (SDL.V2 x y) <- Mouse.getAbsoluteMouseLocation
   return $ Point (epr * fromIntegral x) (epr * fromIntegral y)
 
 -- | Returns the drawable size of the provided window. May differ from window
 --   size if HDPI is enabled.
-getDrawableSize :: (MonadIO m) => SDL.Window -> m Size
+getDrawableSize :: SDL.Window -> IO Size
 getDrawableSize window = do
   SDL.V2 fbWidth fbHeight <- SDL.glGetDrawableSize window
   return $ Size (fromIntegral fbWidth) (fromIntegral fbHeight)
 
 -- | Returns the size of the provided window.
-getWindowSize :: (MonadIO m) => SDL.Window -> m Size
+getWindowSize :: SDL.Window -> IO Size
 getWindowSize window = do
   SDL.V2 rw rh <- SDL.get (SDL.windowSize window)
 
@@ -163,16 +165,16 @@ render to and, depending on the platform, may match window size or not. For
 example, on Windows and Linux Wayland this size may be smaller than the window
 size because of dpr scaling.
 -}
-getViewportSize :: (MonadIO m) => SDL.Window -> Double -> m Size
+getViewportSize :: SDL.Window -> Double -> IO Size
 getViewportSize window dpr = do
   SDL.V2 fw fh <- SDL.glGetDrawableSize window
 
   return $ Size (fromIntegral fw / dpr) (fromIntegral fh / dpr)
 
 -- | Returns the name of the host OS.
-getPlatform :: (MonadIO m) => m Text
+getPlatform :: IO Text
 getPlatform = do
-  platform <- liftIO . peekCString =<< Raw.getPlatform
+  platform <- peekCString =<< Raw.getPlatform
 
   return $ T.pack platform
 

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -15,6 +15,8 @@ Basic types for Main module.
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.Types where
 
 import Control.Applicative ((<|>))

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -87,7 +87,7 @@ data MonomerCtx s e = MonomerCtx {
   -- | Main application model.
   _mcMainModel :: s,
   -- | Active window.
-  _mcWindow :: SDL.Window,
+  _mcWindow :: ~SDL.Window,
   -- | Main window size.
   _mcWindowSize :: Size,
   -- | Device pixel rate.

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -14,7 +14,6 @@ Basic types for Main module.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Main.Types where

--- a/src/Monomer/Main/UserUtil.hs
+++ b/src/Monomer/Main/UserUtil.hs
@@ -9,6 +9,8 @@ Portability : non-portable
 Helper functions for Monomer users, to simplify common operations such as focus
 change and clipboard requests.
 -}
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.UserUtil where
 
 import Control.Applicative ((<|>))

--- a/src/Monomer/Main/Util.hs
+++ b/src/Monomer/Main/Util.hs
@@ -10,6 +10,7 @@ Helper functions for the Main module.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Main.Util where
 
@@ -45,7 +46,7 @@ initMonomerCtx
   -> Double
   -> s
   -> MonomerCtx s e
-initMonomerCtx win channel winSize dpr epr model = MonomerCtx {
+initMonomerCtx ~win channel winSize dpr epr model = MonomerCtx {
   _mcMainModel = model,
   _mcWindow = win,
   _mcWindowSize = winSize,

--- a/src/Monomer/Main/WidgetTask.hs
+++ b/src/Monomer/Main/WidgetTask.hs
@@ -10,7 +10,6 @@ Handles the lifecycle and reporting of generated events of WidgetTasks (single
 message) and Producers (multiple messages).
 -}
 {-# LANGUAGE FlexibleContexts #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Main.WidgetTask (handleWidgetTasks) where

--- a/src/Monomer/Main/WidgetTask.hs
+++ b/src/Monomer/Main/WidgetTask.hs
@@ -11,6 +11,8 @@ message) and Producers (multiple messages).
 -}
 {-# LANGUAGE FlexibleContexts #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Main.WidgetTask (handleWidgetTasks) where
 
 import Control.Concurrent.Async (poll)

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -17,7 +17,6 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Fade (

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -18,6 +18,8 @@ Messages:
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Animation.Fade (
   -- * Configuration
   FadeCfg,

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -16,6 +16,7 @@ Messages:
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Slide (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Alert.hs
+++ b/src/Monomer/Widgets/Containers/Alert.hs
@@ -9,6 +9,8 @@ Portability : non-portable
 Simple alert dialog, displaying a close button and optional title. Usually
 embedded in a zstack component and displayed/hidden depending on context.
 -}
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Alert (
   -- * Configuration
   AlertCfg,

--- a/src/Monomer/Widgets/Containers/Box.hs
+++ b/src/Monomer/Widgets/Containers/Box.hs
@@ -24,7 +24,6 @@ label with an image at its side).
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Box (

--- a/src/Monomer/Widgets/Containers/Box.hs
+++ b/src/Monomer/Widgets/Containers/Box.hs
@@ -25,6 +25,8 @@ label with an image at its side).
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Box (
   -- * Configuration
   BoxCfg,

--- a/src/Monomer/Widgets/Containers/Confirm.hs
+++ b/src/Monomer/Widgets/Containers/Confirm.hs
@@ -12,6 +12,7 @@ context.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Confirm (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Draggable.hs
+++ b/src/Monomer/Widgets/Containers/Draggable.hs
@@ -13,7 +13,6 @@ having to implement a custom widget. Usually works in tandem with
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Draggable (

--- a/src/Monomer/Widgets/Containers/Draggable.hs
+++ b/src/Monomer/Widgets/Containers/Draggable.hs
@@ -14,6 +14,8 @@ having to implement a custom widget. Usually works in tandem with
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Draggable (
   -- * Configuration
   DraggableRender,

--- a/src/Monomer/Widgets/Containers/DropTarget.hs
+++ b/src/Monomer/Widgets/Containers/DropTarget.hs
@@ -16,6 +16,7 @@ the dragged message, otherwise it will not be raised.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.DropTarget (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Dropdown.hs
+++ b/src/Monomer/Widgets/Containers/Dropdown.hs
@@ -19,6 +19,8 @@ to use.
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Dropdown (
   -- * Configuration
   DropdownCfg,

--- a/src/Monomer/Widgets/Containers/Dropdown.hs
+++ b/src/Monomer/Widgets/Containers/Dropdown.hs
@@ -18,8 +18,7 @@ to use.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.Dropdown (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Grid.hs
+++ b/src/Monomer/Widgets/Containers/Grid.hs
@@ -11,6 +11,7 @@ it requests max width * elements as its width, and the max height as its height.
 The reverse happens for vgrid.
 -}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Grid (
   -- * Configuration
@@ -108,7 +109,7 @@ makeFixedGrid isHorizontal config = widget where
     where
       vreqs = accesor <$> vchildren
       nreqs = Seq.length vreqs
-      maxSize = foldl1 sizeReqMergeMax vreqs
+      ~maxSize = foldl1 sizeReqMergeMax vreqs
 
   resize wenv node viewport children = resized where
     style = currentStyle wenv node

--- a/src/Monomer/Widgets/Containers/Keystroke.hs
+++ b/src/Monomer/Widgets/Containers/Keystroke.hs
@@ -33,6 +33,8 @@ These can be combined, for example:
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Keystroke (
   -- * Configuration
   KeystrokeCfg,

--- a/src/Monomer/Widgets/Containers/Keystroke.hs
+++ b/src/Monomer/Widgets/Containers/Keystroke.hs
@@ -32,7 +32,6 @@ These can be combined, for example:
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Keystroke (

--- a/src/Monomer/Widgets/Containers/Scroll.hs
+++ b/src/Monomer/Widgets/Containers/Scroll.hs
@@ -24,6 +24,9 @@ Messages:
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
+{-# LANGUAGE Strict #-}
+
+
 module Monomer.Widgets.Containers.Scroll (
   -- * Configuration
   ScrollCfg,
@@ -375,7 +378,9 @@ makeScroll config state = widget where
   checkFwdStyle wenv node = newNode where
     fwdStyle = _scScrollFwdStyle config
     style = node ^. L.info . L.style
-    (parentStyle, childStyle) = fromJust fwdStyle wenv style
+    (parentStyle, childStyle)
+      | isJust fwdStyle = fromJust fwdStyle wenv style
+      | otherwise = def
     newNode
       | isJust fwdStyle = node
         & L.info . L.style .~ parentStyle

--- a/src/Monomer/Widgets/Containers/Scroll.hs
+++ b/src/Monomer/Widgets/Containers/Scroll.hs
@@ -23,9 +23,7 @@ Messages:
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-
-{-# LANGUAGE Strict #-}
-
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.Scroll (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -14,6 +14,7 @@ customizable, plus its styling.
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.SelectList (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Split.hs
+++ b/src/Monomer/Widgets/Containers/Split.hs
@@ -14,6 +14,7 @@ size requirements of each child node.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.Split (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Stack.hs
+++ b/src/Monomer/Widgets/Containers/Stack.hs
@@ -11,6 +11,9 @@ considers the different type of size requirements and assigns space according to
 the logic defined in 'SizeReq'. If the requested fixed space is larger that the
 viewport of the stack, the content will overflow.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Containers.Stack (
   -- * Configuration
   StackCfg,

--- a/src/Monomer/Widgets/Containers/Stack.hs
+++ b/src/Monomer/Widgets/Containers/Stack.hs
@@ -11,7 +11,6 @@ considers the different type of size requirements and assigns space according to
 the logic defined in 'SizeReq'. If the requested fixed space is larger that the
 viewport of the stack, the content will overflow.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Containers.Stack (

--- a/src/Monomer/Widgets/Containers/ThemeSwitch.hs
+++ b/src/Monomer/Widgets/Containers/ThemeSwitch.hs
@@ -13,6 +13,7 @@ other kind of style configuration, set it on the child node or wrap the
 themeSwitch widget in a "Monomer.Widgets.Containers.Box".
 -}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.ThemeSwitch (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/Tooltip.hs
+++ b/src/Monomer/Widgets/Containers/Tooltip.hs
@@ -16,6 +16,7 @@ element, you may want to use a box.
 -}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.Tooltip (
   -- * Configuration

--- a/src/Monomer/Widgets/Containers/ZStack.hs
+++ b/src/Monomer/Widgets/Containers/ZStack.hs
@@ -15,9 +15,9 @@ The order of the widgets is from bottom to top.
 The container will request the largest combination of horizontal and vertical
 size requested by its child nodes.
 -}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Containers.ZStack (
   -- * Configuration

--- a/src/Monomer/Widgets/Single.hs
+++ b/src/Monomer/Widgets/Single.hs
@@ -10,7 +10,6 @@ Helper for creating widgets without children elements.
 -}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Single (

--- a/src/Monomer/Widgets/Single.hs
+++ b/src/Monomer/Widgets/Single.hs
@@ -11,6 +11,8 @@ Helper for creating widgets without children elements.
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Single (
   -- * Re-exported modules
   module Monomer.Core,

--- a/src/Monomer/Widgets/Singles/Button.hs
+++ b/src/Monomer/Widgets/Singles/Button.hs
@@ -9,11 +9,11 @@ Portability : non-portable
 Button widget, with support for multiline text. At the most basic level, a
 button consists of a caption and an event to raise when clicked.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Button (
   -- * Configuration
@@ -183,11 +183,11 @@ button_ :: WidgetEvent e => Text -> e -> [ButtonCfg s e] -> WidgetNode s e
 button_ caption handler configs = buttonNode where
   config = onClick handler <> mconcat configs
   widget = makeButton caption config
-  buttonNode = defaultWidgetNode "button" widget
+  !buttonNode = defaultWidgetNode "button" widget
     & L.info . L.focusable .~ True
 
 makeButton :: WidgetEvent e => Text -> ButtonCfg s e -> Widget s e
-makeButton caption config = widget where
+makeButton !caption !config = widget where
   widget = createContainer () def {
     containerAddStyleReq = False,
     containerUseScissor = True,
@@ -200,7 +200,7 @@ makeButton caption config = widget where
     containerResize = resize
   }
 
-  buttonType = fromMaybe ButtonNormal (_btnButtonType config)
+  !buttonType = fromMaybe ButtonNormal (_btnButtonType config)
 
   getBaseStyle wenv node
     | ignoreTheme = Nothing
@@ -222,9 +222,9 @@ makeButton caption config = widget where
     nodeStyle = node ^. L.info . L.style
     labelCfg = _btnLabelCfg config
     labelCurrStyle = labelCurrentStyle childOfFocusedStyle
-    labelNode = label_ caption [ignoreTheme, labelCfg, labelCurrStyle]
+    !labelNode = label_ caption [ignoreTheme, labelCfg, labelCurrStyle]
       & L.info . L.style .~ nodeStyle
-    newNode = node
+    !newNode = node
       & L.children .~ Seq.singleton labelNode
 
   init wenv node = result where

--- a/src/Monomer/Widgets/Singles/Button.hs
+++ b/src/Monomer/Widgets/Singles/Button.hs
@@ -13,6 +13,8 @@ button consists of a caption and an event to raise when clicked.
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Singles.Button (
   -- * Configuration
   ButtonCfg,

--- a/src/Monomer/Widgets/Singles/Checkbox.hs
+++ b/src/Monomer/Widgets/Singles/Checkbox.hs
@@ -11,8 +11,10 @@ text, which can be added with a label in the desired position (usually with
 hstack). Alternatively, "Monomer.Widgets.Singles.LabeledCheckbox" provides this
 functionality out of the box.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Checkbox (
   -- * Configuration
@@ -169,7 +171,7 @@ checkboxD_ widgetData configs = checkboxNode where
 
 makeCheckbox
   :: WidgetEvent e => WidgetData s Bool -> CheckboxCfg s e -> Widget s e
-makeCheckbox widgetData config = widget where
+makeCheckbox !widgetData !config = widget where
   widget = createSingle () def {
     singleGetBaseStyle = getBaseStyle,
     singleHandleEvent = handleEvent,

--- a/src/Monomer/Widgets/Singles/ColorPicker.hs
+++ b/src/Monomer/Widgets/Singles/ColorPicker.hs
@@ -11,6 +11,7 @@ Color picker using sliders and numeric fields.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Monomer.Widgets.Singles.ColorPicker (

--- a/src/Monomer/Widgets/Singles/Dial.hs
+++ b/src/Monomer/Widgets/Singles/Dial.hs
@@ -11,12 +11,14 @@ value by keyboard arrows, dragging the mouse or using the wheel.
 
 Similar in objective to "Monomer.Widgets.Singles.Slider", but uses less space.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Dial (
   -- * Configuration
@@ -222,7 +224,7 @@ makeDial
   -> DialCfg s e a
   -> DialState
   -> Widget s e
-makeDial field minVal maxVal config state = widget where
+makeDial !field !minVal !maxVal !config !state = widget where
   widget = createSingle state def {
     singleFocusOnBtnPressed = False,
     singleGetBaseStyle = getBaseStyle,
@@ -285,12 +287,12 @@ makeDial field minVal maxVal config state = widget where
         fastSpeed = max 1 $ round (fromIntegral maxPos / 100)
         warpSpeed = max 1 $ round (fromIntegral maxPos / 10)
         vPos pos = clamp 0 maxPos pos
-        newResult newPos = addReqsEvts (resultNode newNode) newVal where
+        newResult !newPos = addReqsEvts (resultNode newNode) newVal where
           newVal = valueFromPos minVal dragRate newPos
-          newState = state { _dlsPos = newPos }
-          newNode = node
+          !newState = state { _dlsPos = newPos }
+          !newNode = node
             & L.widget .~ makeDial field minVal maxVal config newState
-        handleNewPos newPos
+        handleNewPos !newPos
           | vPos newPos /= pos = Just $ newResult (vPos newPos)
           | otherwise = Nothing
 
@@ -383,7 +385,7 @@ posFromPoint minVal maxVal state dragRate stPoint point = (newPos, newVal) where
   newVal = valueFromPos minVal dragRate newPos
 
 valueFromPos :: DialValue a => a -> Rational -> Integer -> a
-valueFromPos minVal dragRate newPos = newVal where
+valueFromPos !minVal !dragRate !newPos = newVal where
   newVal = minVal + fromFractional (dragRate * fromIntegral newPos)
 
 getDialInfo :: WidgetEnv s e -> WidgetNode s e -> DialCfg s e a -> (Point, Rect)
@@ -395,8 +397,8 @@ getDialInfo wenv node config = (dialCenter, dialArea) where
   dialW = fromMaybe (theme ^. L.dialWidth) (_dlcWidth config)
   dialL = _rX carea + (_rW carea - dialW) / 2
   dialT = _rY carea + (_rH carea - dialW) / 2
-  dialCenter = Point (dialL + dialW / 2) (dialT + dialW / 2)
-  dialArea = Rect dialL dialT dialW dialW
+  !dialCenter = Point (dialL + dialW / 2) (dialT + dialW / 2)
+  !dialArea = Rect dialL dialT dialW dialW
 
 currentStyleConfig :: Rect -> CurrentStyleCfg s e
 currentStyleConfig dialArea = def

--- a/src/Monomer/Widgets/Singles/ExternalLink.hs
+++ b/src/Monomer/Widgets/Singles/ExternalLink.hs
@@ -9,9 +9,11 @@ Portability : non-portable
 Provides a clickable link that opens in the system's browser. It uses OS
 services to open the URI, which means not only URLs can be opened.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.ExternalLink (
   -- * Configuration
@@ -145,7 +147,7 @@ externalLink_ caption url configs = externalLinkNode where
 
 makeExternalLink
   :: WidgetEvent e => Text -> Text -> ExternalLinkCfg s e -> Widget s e
-makeExternalLink caption url config = widget where
+makeExternalLink !caption !url !config = widget where
   widget = createContainer () def {
     containerAddStyleReq = False,
     containerUseScissor = True,
@@ -164,11 +166,10 @@ makeExternalLink caption url config = widget where
     nodeStyle = node ^. L.info . L.style
     labelCfg = _elcLabelCfg config
     labelCurrStyle = labelCurrentStyle childOfFocusedStyle
-    labelNode = label_ caption [ignoreTheme, labelCfg, labelCurrStyle]
+    !labelNode = label_ caption [ignoreTheme, labelCfg, labelCurrStyle]
       & L.info . L.style .~ nodeStyle
-    childNode = labelNode
-    newNode = node
-      & L.children .~ Seq.singleton childNode
+    !newNode = node
+      & L.children .~ Seq.singleton labelNode
 
   init wenv node = result where
     result = resultNode (createChildNode wenv node)

--- a/src/Monomer/Widgets/Singles/Image.hs
+++ b/src/Monomer/Widgets/Singles/Image.hs
@@ -15,10 +15,12 @@ Notes:
 - If you choose 'fitNone', adding 'imageRepeatX' and 'imageRepeatY' won't have
   any kind of effect.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Image (
   -- * Configuration
@@ -277,7 +279,7 @@ imageMem_ name imgData imgSize configs = defaultWidgetNode "image" widget where
 
 makeImage
   :: WidgetEvent e => ImageSource -> ImageCfg e -> ImageState -> Widget s e
-makeImage imgSource config state = widget where
+makeImage !imgSource !config !state = widget where
   widget = createSingle state def {
     singleUseScissor = True,
     singleInit = init,
@@ -288,11 +290,11 @@ makeImage imgSource config state = widget where
     singleRender = render
   }
 
-  isImageMem = case imgSource of
+  !isImageMem = case imgSource of
     ImageMem{} -> True
     _ -> False
 
-  imgName source = case source of
+  imgName !source = case source of
     ImageMem path -> path
     ImagePath path -> path
 

--- a/src/Monomer/Widgets/Singles/Label.hs
+++ b/src/Monomer/Widgets/Singles/Label.hs
@@ -10,6 +10,8 @@ Label widget, with support for multiline text.
 -}
 {-# LANGUAGE DeriveGeneric #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Singles.Label (
   -- * Configuration
   LabelCfg,

--- a/src/Monomer/Widgets/Singles/Label.hs
+++ b/src/Monomer/Widgets/Singles/Label.hs
@@ -9,7 +9,6 @@ Portability : non-portable
 Label widget, with support for multiline text.
 -}
 {-# LANGUAGE DeriveGeneric #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Singles.Label (

--- a/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
+++ b/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
@@ -11,6 +11,7 @@ clickable label.
 -}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Singles.LabeledCheckbox (
   -- * Configuration

--- a/src/Monomer/Widgets/Singles/LabeledRadio.hs
+++ b/src/Monomer/Widgets/Singles/LabeledRadio.hs
@@ -12,6 +12,7 @@ value.
 -}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Singles.LabeledRadio (
   -- * Configuration

--- a/src/Monomer/Widgets/Singles/Radio.hs
+++ b/src/Monomer/Widgets/Singles/Radio.hs
@@ -12,8 +12,10 @@ which should be added as a label in the desired position (usually with hstack).
 Alternatively, 'Monomer.Widgets.Singles.LabeledRadio' provides this
 functionality out of the box.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Radio (
   -- * Configuration
@@ -154,7 +156,7 @@ radioD_ option widgetData configs = radioNode where
     & L.info . L.focusable .~ True
 
 makeRadio :: (Eq a, WidgetEvent e) => WidgetData s a -> a -> RadioCfg s e a -> Widget s e
-makeRadio field option config = widget where
+makeRadio !field !option !config = widget where
   widget = createSingle () def {
     singleGetBaseStyle = getBaseStyle,
     singleGetCurrentStyle = getCurrentStyle,

--- a/src/Monomer/Widgets/Singles/SeparatorLine.hs
+++ b/src/Monomer/Widgets/Singles/SeparatorLine.hs
@@ -14,7 +14,9 @@ The line has the provided width in the direction orthogonal to the layout
 direction, and takes all the available space in the other direction. In case of
 wanting a shorter line, padding should be used.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.SeparatorLine (
   -- * Configuration
@@ -81,14 +83,12 @@ separatorLine_ configs = defaultWidgetNode "separatorLine" widget where
   widget = makeSeparatorLine config
 
 makeSeparatorLine :: SeparatorLineCfg -> Widget s e
-makeSeparatorLine config = widget where
+makeSeparatorLine !config = widget where
   widget = createSingle () def {
     singleGetBaseStyle = getBaseStyle,
     singleGetSizeReq = getSizeReq,
     singleRender = render
   }
-
-  factor = fromMaybe 0 (_slcFactor config)
 
   getBaseStyle wenv node = Just style where
     style = collectTheme wenv L.separatorLineStyle
@@ -97,6 +97,7 @@ makeSeparatorLine config = widget where
     theme = currentTheme wenv node
     direction = wenv ^. L.layoutDirection
     width = fromMaybe (theme ^. L.separatorLineWidth) (_slcWidth config)
+    factor = fromMaybe 0 (_slcFactor config)
 
     isFixed = factor < 0.01
     flexSide = flexSize 10 0.5

--- a/src/Monomer/Widgets/Singles/Slider.hs
+++ b/src/Monomer/Widgets/Singles/Slider.hs
@@ -12,12 +12,14 @@ value by keyboard arrows, dragging the mouse or using the wheel.
 Similar in objective to 'Monomer.Widgets.Singles.Dial', but more convenient in
 some layouts.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.Slider (
   -- * Configuration
@@ -317,7 +319,7 @@ makeSlider
   -> SliderCfg s e a
   -> SliderState
   -> Widget s e
-makeSlider isHz field minVal maxVal config state = widget where
+makeSlider !isHz !field !minVal !maxVal !config !state = widget where
   widget = createSingle state def {
     singleFocusOnBtnPressed = False,
     singleGetBaseStyle = getBaseStyle,
@@ -373,7 +375,7 @@ makeSlider isHz field minVal maxVal config state = widget where
         fastSpeed = max 1 $ round (fromIntegral maxPos / 100)
         warpSpeed = max 1 $ round (fromIntegral maxPos / 10)
 
-        handleNewPos newPos
+        handleNewPos !newPos
           | validPos /= pos = resultFromPos validPos []
           | otherwise = Nothing
           where
@@ -403,22 +405,22 @@ makeSlider isHz field minVal maxVal config state = widget where
       shiftPressed = wenv ^. L.inputStatus . L.keyMod . L.leftShift
       SliderState maxPos pos = state
 
-      resultFromPoint point reqs = resultFromPos newPos reqs where
-        newPos = posFromMouse isHz vp point
+      resultFromPoint !point !reqs = resultFromPos newPos reqs where
+        !newPos = posFromMouse isHz vp point
 
-      resultFromPos newPos extraReqs = Just newResult where
-        newState = state {
+      resultFromPos !newPos !extraReqs = Just newResult where
+        !newState = state {
           _slsPos = newPos
         }
-        newNode = node
+        !newNode = node
           & L.widget .~ makeSlider isHz field minVal maxVal config newState
-        result = resultReqs newNode [RenderOnce]
-        newVal = valueFromPos newPos
+        !result = resultReqs newNode [RenderOnce]
+        !newVal = valueFromPos newPos
 
-        reqs = widgetDataSet field newVal
+        !reqs = widgetDataSet field newVal
           ++ fmap ($ newVal) (_slcOnChangeReq config)
           ++ extraReqs
-        newResult
+        !newResult
           | pos /= newPos = result
               & L.requests <>~ Seq.fromList reqs
           | otherwise = result

--- a/src/Monomer/Widgets/Singles/Spacer.hs
+++ b/src/Monomer/Widgets/Singles/Spacer.hs
@@ -14,6 +14,8 @@ Both adapt to the current layout direction, if any.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Singles.Spacer (
   --  * Configuration
   SpacerCfg,

--- a/src/Monomer/Widgets/Singles/Spacer.hs
+++ b/src/Monomer/Widgets/Singles/Spacer.hs
@@ -14,8 +14,6 @@ Both adapt to the current layout direction, if any.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 
-{-# LANGUAGE Strict #-}
-
 module Monomer.Widgets.Singles.Spacer (
   --  * Configuration
   SpacerCfg,

--- a/src/Monomer/Widgets/Singles/TextArea.hs
+++ b/src/Monomer/Widgets/Singles/TextArea.hs
@@ -8,11 +8,13 @@ Portability : non-portable
 
 Input field for multiline 'Text'.
 -}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StrictData #-}
 
 module Monomer.Widgets.Singles.TextArea (
   -- * Configuration
@@ -239,7 +241,7 @@ makeTextArea
   -> TextAreaCfg s e
   -> TextAreaState
   -> Widget s e
-makeTextArea wdata config state = widget where
+makeTextArea !wdata !config !state = widget where
   widget = createSingle state def {
     singleInit = init,
     singleMerge = merge,
@@ -249,25 +251,25 @@ makeTextArea wdata config state = widget where
     singleRender = render
   }
 
-  caretMs = fromMaybe defCaretMs (_tacCaretMs config)
-  maxLength = _tacMaxLength config
-  maxLines = _tacMaxLines config
-  getModelValue wenv = widgetDataGet (_weModel wenv) wdata
+  !caretMs = fromMaybe defCaretMs (_tacCaretMs config)
+  !maxLength = _tacMaxLength config
+  !maxLines = _tacMaxLines config
+  getModelValue !wenv = widgetDataGet (_weModel wenv) wdata
   -- State
-  currText = _tasText state
-  textLines = _tasTextLines state
+  !currText = _tasText state
+  !textLines = _tasTextLines state
   -- Helpers
-  validText state = validLen && validLines where
+  validText !state = validLen && validLines where
     text = _tasText state
     lines = _tasTextLines state
     validLen = T.length text <= fromMaybe maxBound maxLength
     validLines = length lines <= fromMaybe maxBound maxLines
-  line idx
+  line !idx
     | idx >= 0 && idx < length textLines = Seq.index textLines idx ^. L.text
     | otherwise = ""
-  lineLen = T.length . line
-  totalLines = length textLines
-  lastPos = (lineLen (totalLines - 1), totalLines)
+  !lineLen = T.length . line
+  !totalLines = length textLines
+  !lastPos = (lineLen (totalLines - 1), totalLines)
 
   init wenv node = resultNode newNode where
     text = getModelValue wenv

--- a/src/Monomer/Widgets/Singles/TextDropdown.hs
+++ b/src/Monomer/Widgets/Singles/TextDropdown.hs
@@ -11,6 +11,7 @@ Both header and list content is text based. In case a customizable version is
 is needed, 'Monomer.Widgets.Containers.Dropdown' can be used.
 -}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Singles.TextDropdown (
   -- * Configuratiom

--- a/src/Monomer/Widgets/Singles/TextField.hs
+++ b/src/Monomer/Widgets/Singles/TextField.hs
@@ -12,6 +12,7 @@ Input field for single line 'Text'.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Singles.TextField (
   -- * Configuration

--- a/src/Monomer/Widgets/Util/Drawing.hs
+++ b/src/Monomer/Widgets/Util/Drawing.hs
@@ -10,7 +10,6 @@ Utility drawing functions. Built on top the lower level primitives provided by
 "Monomer.Graphics.Types.Renderer".
 -}
 {-# LANGUAGE RecordWildCards #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Drawing (

--- a/src/Monomer/Widgets/Util/Drawing.hs
+++ b/src/Monomer/Widgets/Util/Drawing.hs
@@ -11,6 +11,8 @@ Utility drawing functions. Built on top the lower level primitives provided by
 -}
 {-# LANGUAGE RecordWildCards #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Drawing (
   drawInScissor,
   drawInTranslation,

--- a/src/Monomer/Widgets/Util/Focus.hs
+++ b/src/Monomer/Widgets/Util/Focus.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Helper functions for focus handling.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Focus (

--- a/src/Monomer/Widgets/Util/Focus.hs
+++ b/src/Monomer/Widgets/Util/Focus.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Helper functions for focus handling.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Focus (
   isNodeFocused,
   isNodeInfoFocused,

--- a/src/Monomer/Widgets/Util/Hover.hs
+++ b/src/Monomer/Widgets/Util/Hover.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Helper functions for hover related actions.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Hover (

--- a/src/Monomer/Widgets/Util/Hover.hs
+++ b/src/Monomer/Widgets/Util/Hover.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Helper functions for hover related actions.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Hover (
   isPointInNodeVp,
   isPointInNodeEllipse,

--- a/src/Monomer/Widgets/Util/Keyboard.hs
+++ b/src/Monomer/Widgets/Util/Keyboard.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Utility functions for widget keyboard handling.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Keyboard (
   isShortCutControl,
   isKeyboardCopy,

--- a/src/Monomer/Widgets/Util/Keyboard.hs
+++ b/src/Monomer/Widgets/Util/Keyboard.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Utility functions for widget keyboard handling.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Keyboard (

--- a/src/Monomer/Widgets/Util/Parser.hs
+++ b/src/Monomer/Widgets/Util/Parser.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Very basic parsing helpers used by numeric input fields.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Parser where

--- a/src/Monomer/Widgets/Util/Parser.hs
+++ b/src/Monomer/Widgets/Util/Parser.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Very basic parsing helpers used by numeric input fields.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Parser where
 
 import Control.Applicative ((<|>))

--- a/src/Monomer/Widgets/Util/Style.hs
+++ b/src/Monomer/Widgets/Util/Style.hs
@@ -10,7 +10,6 @@ Helper functions for style related operations.
 -}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Style (

--- a/src/Monomer/Widgets/Util/Style.hs
+++ b/src/Monomer/Widgets/Util/Style.hs
@@ -11,6 +11,8 @@ Helper functions for style related operations.
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Style (
   collectStyleField,
   collectStyleField_,

--- a/src/Monomer/Widgets/Util/Text.hs
+++ b/src/Monomer/Widgets/Util/Text.hs
@@ -10,6 +10,8 @@ Helper functions to text related operations in widgets.
 -}
 {-# LANGUAGE BangPatterns #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Text (
   getTextMetrics,
   getTextSize,

--- a/src/Monomer/Widgets/Util/Text.hs
+++ b/src/Monomer/Widgets/Util/Text.hs
@@ -8,8 +8,6 @@ Portability : non-portable
 
 Helper functions to text related operations in widgets.
 -}
-{-# LANGUAGE BangPatterns #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Text (
@@ -34,13 +32,13 @@ import qualified Monomer.Core.Lens as L
 getTextMetrics :: WidgetEnv s e -> StyleState -> TextMetrics
 getTextMetrics wenv style = textMetrics where
   fontMgr = wenv ^. L.fontManager
-  !textMetrics = computeTextMetrics fontMgr font fontSize
+  textMetrics = computeTextMetrics fontMgr font fontSize
   font = styleFont style
   fontSize = styleFontSize style
 
 -- | Returns the size of the text using the active style and default options.
 getTextSize :: WidgetEnv s e -> StyleState -> Text -> Size
-getTextSize wenv style !text = size where
+getTextSize wenv style text = size where
   fontMgr = wenv ^. L.fontManager
   size = calcTextSize_ fontMgr style SingleLine KeepSpaces Nothing Nothing text
 
@@ -67,7 +65,7 @@ getSingleTextLineRect
   -> AlignTV        -- ^ The vertical alignment.
   -> Text           -- ^ The text to measure.
   -> Rect           -- ^ The used rect. May be larger than the bounding rect.
-getSingleTextLineRect wenv style !rect !alignH !alignV !text = textRect where
+getSingleTextLineRect wenv style rect alignH alignV text = textRect where
   fontMgr = wenv ^. L.fontManager
   font = styleFont style
   fSize = styleFontSize style
@@ -95,9 +93,9 @@ getSingleTextLineRect wenv style !rect !alignH !alignV !text = textRect where
 
 -- | Returns the glyphs of a single line of text.
 getTextGlyphs :: WidgetEnv s e -> StyleState -> Text -> Seq GlyphPos
-getTextGlyphs wenv style !text = glyphs where
+getTextGlyphs wenv style text = glyphs where
   fontMgr = wenv ^. L.fontManager
   font = styleFont style
   fSize = styleFontSize style
   fSpcH = styleFontSpaceH style
-  !glyphs = computeGlyphsPos fontMgr font fSize fSpcH text
+  glyphs = computeGlyphsPos fontMgr font fSize fSpcH text

--- a/src/Monomer/Widgets/Util/Theme.hs
+++ b/src/Monomer/Widgets/Util/Theme.hs
@@ -10,6 +10,8 @@ Helper functions for loading theme values.
 -}
 {-# LANGUAGE RankNTypes #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Theme where
 
 import Control.Lens (Lens', (&), (^.), (^?), (.~), (?~), (<>~), at, non)

--- a/src/Monomer/Widgets/Util/Theme.hs
+++ b/src/Monomer/Widgets/Util/Theme.hs
@@ -9,7 +9,6 @@ Portability : non-portable
 Helper functions for loading theme values.
 -}
 {-# LANGUAGE RankNTypes #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Theme where

--- a/src/Monomer/Widgets/Util/Types.hs
+++ b/src/Monomer/Widgets/Util/Types.hs
@@ -8,6 +8,9 @@ Portability : non-portable
 
 Common types for widget related functions.
 -}
+
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Types (
   IsHovered,
   IsFocused,

--- a/src/Monomer/Widgets/Util/Types.hs
+++ b/src/Monomer/Widgets/Util/Types.hs
@@ -8,7 +8,6 @@ Portability : non-portable
 
 Common types for widget related functions.
 -}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Types (

--- a/src/Monomer/Widgets/Util/Widget.hs
+++ b/src/Monomer/Widgets/Util/Widget.hs
@@ -10,7 +10,6 @@ Helper functions for widget lifecycle.
 -}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
 {-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Util.Widget (

--- a/src/Monomer/Widgets/Util/Widget.hs
+++ b/src/Monomer/Widgets/Util/Widget.hs
@@ -11,6 +11,8 @@ Helper functions for widget lifecycle.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# LANGUAGE Strict #-}
+
 module Monomer.Widgets.Util.Widget (
   defaultWidgetNode,
   isWidgetVisible,

--- a/test/unit/Monomer/TestUtil.hs
+++ b/test/unit/Monomer/TestUtil.hs
@@ -33,7 +33,6 @@ import Monomer.Graphics
 import Monomer.Main.Handlers
 import Monomer.Main.Types
 import Monomer.Main.Util
-import Monomer.Widgets.Util.Widget
 
 import qualified Monomer.Lens as L
 


### PR DESCRIPTION
Fixes the issue described in https://github.com/fjvallarino/monomer/issues/14.

In general, the fix consists of adding strictness to styling helper functions and Composite and Container's event handling logic. Where it made sense, data types and helper modules were also made strict.