### PR TITLE
Temporarily use previous Stackage version, 18.6, to avoid Windows build issue

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 
 #resolver: lts-14.27
 #resolver: lts-17.15
-resolver: lts-18.7
+resolver: lts-18.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -21,6 +21,6 @@ packages:
 snapshots:
 - completed:
     size: 587113
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/7.yaml
-    sha256: c8617e042150e4bf412d011c234aba6189f789d0cd2bd4f1a1a9ca9a0ef5d042
-  original: lts-18.7
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/6.yaml
+    sha256: f74c482d7c93739ecf3abfbc0f2dea1c20a2dfb2462c689846ed55a9653b66f7
+  original: lts-18.6


### PR DESCRIPTION
As mentioned in https://github.com/commercialhaskell/stackage/issues/6176, Stackage 18.7 has build issues on Windows. Temporarily, until a new LTS version is released that builds on all platforms, the version is set to 18.6.