### PR TITLE
Improve Windows build/setup

### DIFF
--- a/cbits/fontmanager.c
+++ b/cbits/fontmanager.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <memory.h>
 
 #include "fontstash.h"

--- a/docs/tutorials/00-setup.md
+++ b/docs/tutorials/00-setup.md
@@ -76,8 +76,6 @@ stack exec -- pacman -S mingw-w64-x86_64-glew
 
 Inside your project's directory:
 
-### macOS / Linux
-
 ```bash
 stack build
 ```
@@ -92,12 +90,6 @@ As a workaround, an application configuration option called
 `appRenderOnMainThread` is available. It can be added to the `config` list of
 the starter application or to the corresponding section of any of the examples.
 
-### Windows
-
-```bash
-stack build --flag regex-posix:_regex-posix-clib
-```
-
 ## Build the examples included with the library
 
 In case you want to test the examples the library provides, you need to clone
@@ -109,26 +101,12 @@ git clone https://github.com/fjvallarino/monomer.git
 
 Then, inside the cloned directory, build the project with:
 
-### Linux and macOS
-
 ```bash
 stack build
 ```
 
-### Windows
-
-If you're using Windows, you have to do some extra steps and provide additional
-flags as in the starter project:
-
-```bash
-stack setup
-stack exec -- pacman -S mingw-w64-x86_64-pkg-config
-stack exec -- pacman -S mingw-w64-x86_64-SDL2
-stack exec -- pacman -S mingw-w64-x86_64-freeglut
-stack exec -- pacman -S mingw-w64-x86_64-glew
-
-stack build --flag regex-posix:_regex-posix-clib
-```
+In case you have not followed the instructions for the starter project, you
+still need to install the [dependencies](#libraries-sdl2-and-glew).
 
 ### Running the examples
 

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -18,7 +18,6 @@ module Monomer.Core.WidgetTypes where
 
 import Control.Concurrent (MVar)
 import Control.Lens (ALens')
-import Data.ByteString.Lazy (ByteString)
 import Data.Default
 import Data.Map.Strict (Map)
 import Data.Sequence (Seq)

--- a/src/Monomer/Widgets/Util/Widget.hs
+++ b/src/Monomer/Widgets/Util/Widget.hs
@@ -40,7 +40,6 @@ module Monomer.Widgets.Util.Widget (
 
 import Control.Concurrent (threadDelay)
 import Control.Lens ((&), (^#), (#~), (^.), (^?), (.~), (%~), _Just)
-import Data.ByteString.Lazy (ByteString)
 import Data.Default
 import Data.Maybe
 import Data.Map.Strict (Map)

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - nanovg-0.8.0.0@sha256:0183b4295ccc2dfb94a7eca977fb45759e1480652578936aa7b71bb4b9626480,4742
-  - regex-posix-clib-2.7@sha256:998fca06da3d719818f0691ef0b8b9b7375afeea228cb08bd9e2db53f96b0cd7,1232
 
   # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,13 +11,6 @@ packages:
       sha256: 0acd44b6f4f50d20bb162084895e052d9437e4de18f988c06e5acf9f85497e1c
   original:
     hackage: nanovg-0.8.0.0@sha256:0183b4295ccc2dfb94a7eca977fb45759e1480652578936aa7b71bb4b9626480,4742
-- completed:
-    hackage: regex-posix-clib-2.7@sha256:998fca06da3d719818f0691ef0b8b9b7375afeea228cb08bd9e2db53f96b0cd7,1232
-    pantry-tree:
-      size: 524
-      sha256: 5bf20952472d930323766d250f5fbbe3fe6f2cd3d931e5cf7b62a238ab2099ff
-  original:
-    hackage: regex-posix-clib-2.7@sha256:998fca06da3d719818f0691ef0b8b9b7375afeea228cb08bd9e2db53f96b0cd7,1232
 snapshots:
 - completed:
     size: 587113


### PR DESCRIPTION
This PR includes several improvements related to the Windows build.

The main one involves standardizing the build process, given the fix explained [here](https://github.com/haskell-hvr/regex-posix/issues/7#issuecomment-882511096) eliminates the need of providing a platform-specific flag.

Setup docs have been updated to reflect these changes.
