### PR TITLE
Reduce memory usage by sharing wreq session among image widget instances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 1.0.0.4 - In development
+
+- Reduce memory usage by sharing wreq session among image widget instances.
+
 ### 1.0.0.3
 
 - Consume and forward all available messages from Producers on each cycle.

--- a/docs/examples/02-books.md
+++ b/docs/examples/02-books.md
@@ -18,9 +18,10 @@ the JSON response returned by the API. Only a few fields are retrieved and
 displayed in the UI, but quite a few more are available.
 
 The `BooksSearch` event is used to run a Task that calls the https endpoint.
-When a successful response is received, and event with the result is sent back
-to the application. The same happens with errors, which are displayed as an
-alert dialog.
+When a successful response is received, an event with the result is sent back to
+the application. The same happens with errors, which are displayed as an alert
+dialog. Note: In case you use `wreq` for your own projects, it is recommended
+that you use Session; without it, memory consumption increases heavily.
 
 The zstack widget is used to always keep the background visible while showing
 details or errors. Unless specifically requested, input is only received by the


### PR DESCRIPTION
As mentioned at the bottom of the [tutorial](http://www.serpentine.com/wreq/tutorial.html), Session is required to reduce memory consumption when making HTTP/HTTPS requests with wreq.

This PR switches the image widget from making independent requests to sharing a Session among all the image widget instances. Testing the Books example, memory consumption was greatly reduced when loading multiple images.