### PR TITLE
Generate IgnoreParentEvents request from widgets that handle Wheel event (avoids issues with scroll widget moving the content)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,9 @@
 
 ### Fixed
 
-- Keep old Composite root if model has not changed. This did not affect previous code,
+- Keep old Composite root if model has not changed. This does not affect previous code,
   it is only relevant with new features.
+- Generate `IgnoreParentEvents` request from widgets that handle Wheel event (avoids issues with scroll widget moving the content).
 
 ### Changed
 

--- a/src/Monomer/Widgets/Singles/Base/InputField.hs
+++ b/src/Monomer/Widgets/Singles/Base/InputField.hs
@@ -492,7 +492,7 @@ makeInputField !config !state = widget where
       | isJust wheelHandler -> Just result where
         handlerRes = fromJust wheelHandler state point move dir
         (newText, newPos, newSel) = handlerRes
-        reqs = [RenderOnce]
+        reqs = [RenderOnce, IgnoreParentEvents]
         result = genInputResult wenv node True newText newPos newSel reqs
 
     -- Handle keyboard shortcuts and possible cursor changes

--- a/src/Monomer/Widgets/Singles/Dial.hs
+++ b/src/Monomer/Widgets/Singles/Dial.hs
@@ -320,7 +320,8 @@ makeDial !field !minVal !maxVal !config !state = widget where
       tmpPos = pos + round (wy * wheelRate)
       newPos = clamp 0 maxPos tmpPos
       newVal = valueFromPos minVal dragRate newPos
-      result = addReqsEvts (resultReqs node [RenderOnce]) newVal
+      reqs = [RenderOnce, IgnoreParentEvents]
+      result = addReqsEvts (resultReqs node reqs) newVal
     _ -> Nothing
     where
       theme = currentTheme wenv node

--- a/src/Monomer/Widgets/Singles/Slider.hs
+++ b/src/Monomer/Widgets/Singles/Slider.hs
@@ -391,11 +391,12 @@ makeSlider !isHz !field !minVal !maxVal !config !state = widget where
 
     ButtonAction point btn BtnReleased clicks  -> resultFromPoint point []
 
-    WheelScroll _ (Point _ wy) wheelDirection -> resultFromPos newPos [] where
+    WheelScroll _ (Point _ wy) wheelDirection -> resultFromPos newPos reqs where
       wheelCfg = fromMaybe (theme ^. L.sliderWheelRate) (_slcWheelRate config)
       wheelRate = fromRational wheelCfg
       tmpPos = pos + round (wy * wheelRate)
       newPos = clamp 0 maxPos tmpPos
+      reqs = [IgnoreParentEvents]
     _ -> Nothing
     where
       theme = currentTheme wenv node

--- a/test/unit/Monomer/Widgets/Singles/DialSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/DialSpec.hs
@@ -191,11 +191,17 @@ handleWheelVal = describe "handleWheelVal" $ do
     let steps = [WheelScroll p (Point 0 (-200)) WheelNormal]
     evts steps `shouldBe` Seq.singleton (DialChanged (-200))
 
+  it "should generate IgnoreParentEvents when using the wheel" $ do
+    let p = Point 320 240
+    let steps = [WheelScroll p (Point 0 (-64)) WheelNormal]
+    reqs steps `shouldSatisfy` (IgnoreParentEvents `elem`)
+
   where
     wenv = mockWenv (TestModel 0)
       & L.theme .~ darkTheme
     dialNode = dialV_ 0 DialChanged (-500) 500 [wheelRate 1]
     evts es = nodeHandleEventEvts wenv es dialNode
+    reqs es = nodeHandleEventReqs wenv es dialNode
 
 handleShiftFocus :: Spec
 handleShiftFocus = describe "handleShiftFocus" $ do

--- a/test/unit/Monomer/Widgets/Singles/NumericFieldSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/NumericFieldSpec.hs
@@ -118,6 +118,11 @@ handleEventIntegral = describe "handleEventIntegral" $ do
     model steps3 ^. integralValue `shouldBe` 100
     model steps4 ^. integralValue `shouldBe` 1501
 
+  it "should generate IgnoreParentEvents when using the wheel" $ do
+    let p = Point 100 10
+    let steps = [WheelScroll p (Point 0 (-64)) WheelNormal]
+    reqs steps `shouldSatisfy` (IgnoreParentEvents `elem`)
+
   it "should generate an event when focus is received" $
     events [evtFocus] `shouldBe` Seq.singleton (GotFocus emptyPath)
 
@@ -133,6 +138,7 @@ handleEventIntegral = describe "handleEventIntegral" $ do
     model es = nodeHandleEventModel wenv (evtFocus : es) intNode
     modelBasic es = nodeHandleEventModel wenv es basicIntNode
     events es = nodeHandleEventEvts wenv es intNode
+    reqs es = nodeHandleEventReqs wenv es intNode
 
 handleEventValueIntegral :: Spec
 handleEventValueIntegral = describe "handleEventIntegral" $ do
@@ -317,6 +323,11 @@ handleEventFractional = describe "handleEventFractional" $ do
     model steps3 ^. fractionalValue `shouldBe` Just 870
     model steps4 ^. fractionalValue `shouldBe` Just 1501
 
+  it "should generate IgnoreParentEvents when using the wheel" $ do
+    let p = Point 100 10
+    let steps = [WheelScroll p (Point 0 (-64)) WheelNormal]
+    reqs steps `shouldSatisfy` (IgnoreParentEvents `elem`)
+
   it "should generate an event when focus is received" $
     events evtFocus `shouldBe` Seq.singleton (GotFocus emptyPath)
 
@@ -332,6 +343,7 @@ handleEventFractional = describe "handleEventFractional" $ do
     model es = nodeHandleEventModel wenv es floatNode
     modelBasic es = nodeHandleEventModel wenv es basicFractionalNode
     events evt = nodeHandleEventEvts wenv [evt] floatNode
+    reqs es = nodeHandleEventReqs wenv es floatNode
 
 handleEventValueFractional :: Spec
 handleEventValueFractional = describe "handleEventValueFractional" $ do

--- a/test/unit/Monomer/Widgets/Singles/SliderSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/SliderSpec.hs
@@ -324,11 +324,17 @@ handleWheelH = describe "handleWheelH" $ do
     let steps = [WheelScroll p (Point 0 100) WheelNormal]
     model steps ^. sliderVal `shouldBe` 300
 
+  it "should generate IgnoreParentEvents when using the wheel" $ do
+    let p = Point 100 10
+    let steps = [WheelScroll p (Point 0 (-64)) WheelNormal]
+    reqs steps `shouldSatisfy` (IgnoreParentEvents `elem`)
+
   where
     wenv = mockWenvEvtUnit (TestModel 200)
       & L.theme .~ darkTheme
     sliderNode = hslider_ sliderVal (-500) 500 [wheelRate 1]
     model es = nodeHandleEventModel wenv es sliderNode
+    reqs es = nodeHandleEventReqs wenv es sliderNode
 
 handleWheelValV :: Spec
 handleWheelValV = describe "handleWheelValV" $ do


### PR DESCRIPTION
When using the wheel on `numericField`, `dial` or `slider` inside a `scroll` widget, not only the value would change, but also the content will move because of scroll event handling. This PR avoids this by ignoring the scroll wheel when a child widget has already handled it.