### PR TITLE
nix: discover and build examples

### DIFF
--- a/nix/monomer.nix
+++ b/nix/monomer.nix
@@ -33,30 +33,9 @@ with super.haskellPackages.extend (self: super:
           '';
         })) GLEW;
     };
-    executables = {
-      todo = mkApp rec {
+    executables = builtins.mapAttrs (name: _:
+      mkApp {
+        inherit name;
         drv = libraries.monomer;
-        name = "todo";
-      };
-      books = mkApp rec {
-        drv = libraries.monomer;
-        name = "books";
-      };
-      ticker = mkApp rec {
-        drv = libraries.monomer;
-        name = "ticker";
-      };
-      generative = mkApp rec {
-        drv = libraries.monomer;
-        name = "generative";
-      };
-      tutorial = mkApp rec {
-        drv = libraries.monomer;
-        name = "tutorial";
-      };
-      opengl = mkApp rec {
-        drv = libraries.monomer;
-        name = "opengl";
-      };
-    };
+      }) (builtins.readDir ../examples);
   }


### PR DESCRIPTION
This is to simplify the discovery of new examples and add them automatically as application targets in Nix. There's no change in behavior.