### PR TITLE
Add onChange event to scroll widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,10 +6,13 @@
   is done to avoid issues if the handled type is later changed (https://github.com/fjvallarino/monomer/issues/46).
 - If the `WidgetType` of the root item in a `Composite` changes during `merge`, initialize the new widget instead
   of merging with the old one (https://github.com/fjvallarino/monomer/issues/50).
+- The arrow position in `dropdown` is now correct when a dropdown is taller than one line (thanks @Dretch!).
 
 ### Added
 
 - Export `drawArrowUp` from `Drawing` module.
+- The `image` widget now supports a `fitEither` option (thanks @Kyarigwo!).
+- The `scroll` widget now raises `onChange` events, providing the current `ScrollStatus`.
 
 ### Changed
 

--- a/src/Monomer/Widgets/Containers/Scroll.hs
+++ b/src/Monomer/Widgets/Containers/Scroll.hs
@@ -716,9 +716,11 @@ makeScroll config state = widget where
     }
     newNode = node
       & L.widget .~ makeScroll config newState
+      -- For scrollInfoReqs only, since parent will set viewport later
+      & L.info . L.viewport .~ viewport
 
     updateReqs
-      | childPosChanged state newState = scrollInfoReqs node config newState
+      | childPosChanged state newState = scrollInfoReqs newNode config newState
       | otherwise = []
     visibleResult = resultNode newNode
       & L.requests .~ Seq.fromList updateReqs


### PR DESCRIPTION
Exposing the current state of the `scroll` widget allows for use cases not initially covered. 

Discussion here: https://github.com/fjvallarino/monomer/issues/41