### PR TITLE
Initialize new widget if widgetType changed when model is updated in Composite

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 - Widgets that receive polymorphic types now append the handled type to their `WidgetType`. This
   is done to avoid issues if the handled type is later changed (https://github.com/fjvallarino/monomer/issues/46).
+- If the `WidgetType` of the root item in a `Composite` changes during `merge`, initialize the new widget instead
+  of merging with the old one (https://github.com/fjvallarino/monomer/issues/50).
 
 ### Added
 


### PR DESCRIPTION
If the `WidgetType` of the root item in a `Composite` changes during `merge`, initialize the new widget instead of merging with the old one.

Discussed here: https://github.com/fjvallarino/monomer/issues/50
