### PR TITLE
Make the arrow position nicer when a dropdown is taller than one line.

### DIFF
--- a/src/Monomer/Widgets/Containers/Dropdown.hs
+++ b/src/Monomer/Widgets/Containers/Dropdown.hs
@@ -506,8 +506,7 @@ makeDropdown widgetData items makeMain makeRow config state = widget where
       Rect x y w h = contentArea
       size = style ^. L.text . non def . L.fontSize . non def
       arrowW = unFontSize size / 2
-      dh = (h - arrowW) / 2
-      arrowRect = Rect (x + w - dh * 2) (y + dh * 1.25) arrowW (arrowW / 2)
+      arrowRect = Rect (x + w - arrowW) (y + h / 2 - arrowW / 3) arrowW (arrowW / 2)
 
   renderOverlay renderer wenv overlayNode = renderAction where
     widget = overlayNode ^. L.widget


### PR DESCRIPTION
I have taken the liberty of opening a PR here, because this looks obviously broken to me (in this, probably rare, edge case), and the fix seemed reasonably obvious too.

## Before this change
The taller the dropdown became, the weirder the arrow position was.
![sans-arrow-fix](https://user-images.githubusercontent.com/1428731/147884558-720079f7-3f0f-46b9-8ef6-ce98906023de.png)

## After this change
![with-arrow-fix](https://user-images.githubusercontent.com/1428731/147884562-5eb85eb5-004c-4b52-b455-52956493e31d.png)