### PR TITLE
Added fitEither option to Image widget

### DIFF
--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -265,6 +265,10 @@ class CmbFitWidth t where
 class CmbFitHeight t where
   fitHeight :: t
 
+-- | Either fitWidth or fitHeight such that image does not overflow viewport
+class CmbFitEither t where
+  fitEither :: t
+
 -- | Applies nearest filtering when stretching an image.
 class CmbImageNearest t where
   imageNearest :: t


### PR DESCRIPTION
I have added a new fit option to the image widget, 'fitEither', which will use either 'fitWidth' or 'fitHeight', whichever does not truncate any of the image.  So it allows the image to be as large as possible, but keep the ratio.

I am not sure about is how to handle the imageRepeatX and imageRepeatY options.  I think that they should be disabled, like for fitNone, but that will require more changes to the code.