### PR TITLE
Generate click events for mouse middle button

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 - If the `WidgetType` of the root item in a `Composite` changes during `merge`, initialize the new widget instead
   of merging with the old one (https://github.com/fjvallarino/monomer/issues/50).
 - The arrow position in `dropdown` is now correct when a dropdown is taller than one line (thanks @Dretch!).
+- The middle button click is now handled by `convertEvents`, and in turn reported to widgets.
 
 ### Added
 

--- a/src/Monomer/Event/Core.hs
+++ b/src/Monomer/Event/Core.hs
@@ -85,6 +85,7 @@ mouseClick mousePos (SDL.MouseButtonEvent eventData) = systemEvent where
     button = case SDL.mouseButtonEventButton eventData of
       SDL.ButtonLeft -> Just BtnLeft
       SDL.ButtonRight -> Just BtnRight
+      SDL.ButtonMiddle -> Just BtnMiddle
       _ -> Nothing
 
     action = case SDL.mouseButtonEventMotion eventData of


### PR DESCRIPTION
Add missing case for middle button actions.

Reported in https://github.com/fjvallarino/monomer/issues/63
