### PR TITLE
Reduce dependencies on unused or lightly used packages

### DIFF
--- a/examples/ticker/BinanceTypes.hs
+++ b/examples/ticker/BinanceTypes.hs
@@ -22,11 +22,13 @@ import Control.Concurrent.STM.TChan
 import Control.Lens.TH
 import Data.Aeson
 import Data.Default
+import Data.Fixed
 import Data.Foldable (asum)
 import Data.Maybe
 import Data.Map (Map)
-import Data.Scientific
 import Data.Text (Text, pack)
+
+type FixedFloat = Pico
 
 data ServerRequest = ServerRequest {
   _srqRequestId :: Int,
@@ -68,12 +70,12 @@ instance FromJSON ServerError where
 data Ticker = Ticker {
   _tckSymbolPair :: Text,
   _tckTs :: Int,
-  _tckOpen :: Scientific,
-  _tckClose :: Scientific,
-  _tckHigh :: Scientific,
-  _tckLow :: Scientific,
-  _tckVolume :: Scientific,
-  _tckTrades :: Scientific
+  _tckOpen :: FixedFloat,
+  _tckClose :: FixedFloat,
+  _tckHigh :: FixedFloat,
+  _tckLow :: FixedFloat,
+  _tckVolume :: FixedFloat,
+  _tckTrades :: FixedFloat
 } deriving (Eq, Show)
 
 instance FromJSON Ticker where

--- a/examples/ticker/Main.hs
+++ b/examples/ticker/Main.hs
@@ -25,9 +25,9 @@ import Data.Aeson
 import Data.Default
 import Data.Foldable (foldl')
 import Data.Maybe
-import Data.Scientific
 import Data.Text (Text)
 
+import qualified Formatting as F
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Network.Wreq as W
@@ -46,10 +46,10 @@ type TickerNode = WidgetNode TickerModel TickerEvt
 
 tickerPct :: Ticker -> TickerNode
 tickerPct t = pctLabel where
-  diff = toRealFloat $ 100 * (t ^. close - t ^. open)
-  pct = diff / toRealFloat (t ^. open)
+  diff = 100 * (t ^. close - t ^. open)
+  pct = diff / t ^. open
 
-  pctText = formatTickerPct (fromFloatDigits pct) <> "%"
+  pctText = formatTickerPct pct <> "%"
   pctColor
     | abs pct < 0.01 = rgbHex "#428FE0"
     | pct > 0 = rgbHex "#51A39A"
@@ -271,11 +271,11 @@ collectJustM action = do
       xs <- collectJustM action
       return (x : xs)
 
-formatTickerValue :: Scientific -> Text
-formatTickerValue = T.pack . formatScientific Fixed (Just 8)
+formatTickerValue :: FixedFloat -> Text
+formatTickerValue = F.sformat (F.fixed 8)
 
-formatTickerPct :: Scientific -> Text
-formatTickerPct = T.pack . formatScientific Fixed (Just 2)
+formatTickerPct :: FixedFloat -> Text
+formatTickerPct = F.sformat (F.fixed 2)
 
 initialList :: [Text]
 initialList = ["BTCUSDT", "ETHBTC", "BNBBTC", "ADABTC", "DOTBTC", "XRPBTC",

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -496,8 +496,7 @@ test-suite monomer-test
       OverloadedStrings
   ghc-options: -fwarn-incomplete-patterns
   build-depends:
-      HUnit ==1.6.*
-    , JuicyPixels >=3.2.9 && <3.5
+      JuicyPixels >=3.2.9 && <3.5
     , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
@@ -506,7 +505,6 @@ test-suite monomer-test
     , bytestring-to-vector ==0.3.*
     , containers >=0.5.11 && <0.7
     , data-default >=0.5 && <0.8
-    , directory ==1.3.*
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
     , formatting >=6.0 && <8.0
@@ -518,7 +516,6 @@ test-suite monomer-test
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
-    , silently ==1.2.*
     , stm ==2.5.*
     , text >=1.2 && <2.1
     , text-show >=3.7 && <3.10

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -156,7 +156,7 @@ library
       c2hs
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
     , base >=4.11 && <5
@@ -202,7 +202,7 @@ executable books
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , aeson >=1.4 && <2.3
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
@@ -246,7 +246,7 @@ executable generative
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
     , base >=4.11 && <5
@@ -288,7 +288,6 @@ executable opengl
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
     , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
@@ -332,7 +331,7 @@ executable ticker
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , aeson >=1.4 && <2.3
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
@@ -377,7 +376,7 @@ executable todo
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
     , base >=4.11 && <5
@@ -425,7 +424,7 @@ executable tutorial
   ghc-options: -threaded
   build-depends:
       JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
     , base >=4.11 && <5
@@ -448,7 +447,7 @@ executable tutorial
     , stm ==2.5.*
     , text >=1.2 && <2.1
     , text-show >=3.7 && <3.10
-    , time >=1.8 && <1.13
+    , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
     , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
@@ -514,7 +513,7 @@ test-suite monomer-test
   build-depends:
       HUnit ==1.6.*
     , JuicyPixels >=3.2.9 && <3.5
-    , OpenGL ==3.0.*
+    , OpenGLRaw ==3.3.*
     , async >=2.1 && <2.3
     , attoparsec >=0.12 && <0.15
     , base >=4.11 && <5

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -179,7 +179,6 @@ library
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   if os(windows)
@@ -227,7 +226,6 @@ executable books
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
@@ -271,7 +269,6 @@ executable generative
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
@@ -313,7 +310,6 @@ executable opengl
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
@@ -350,14 +346,12 @@ executable ticker
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
     , safe ==0.3.*
-    , scientific ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , websockets ==0.12.*
     , wreq >=0.5.2 && <0.6
@@ -400,7 +394,6 @@ executable todo
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
@@ -449,7 +442,6 @@ executable tutorial
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
@@ -540,7 +532,6 @@ test-suite monomer-test
     , text-show >=3.7 && <3.10
     , time >=1.8 && <1.16
     , transformers >=0.5 && <0.7
-    , unordered-containers >=0.2.8 && <0.3
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
   default-language: Haskell2010

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -172,7 +172,6 @@ library
     , mtl >=2.1 && <2.3
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -219,7 +218,6 @@ executable books
     , mtl >=2.1 && <2.3
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -262,7 +260,6 @@ executable generative
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -303,7 +300,6 @@ executable opengl
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -345,7 +341,6 @@ executable ticker
     , mtl >=2.1 && <2.3
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -387,7 +382,6 @@ executable todo
     , mtl >=2.1 && <2.3
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -435,7 +429,6 @@ executable tutorial
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , stm ==2.5.*
     , text >=1.2 && <2.1
@@ -524,7 +517,6 @@ test-suite monomer-test
     , mtl >=2.1 && <2.3
     , nanovg >=0.8 && <1.0
     , process ==1.6.*
-    , safe ==0.3.*
     , sdl2 >=2.5.0 && <2.6
     , silently ==1.2.*
     , stm ==2.5.*

--- a/package.yaml
+++ b/package.yaml
@@ -137,8 +137,5 @@ tests:
     ghc-options:
       - -fwarn-incomplete-patterns
     dependencies:
-      - directory >= 1.3 && < 1.4
       - monomer
       - hspec >= 2.4 && < 3.0
-      - HUnit >= 1.6 && < 1.7
-      - silently >= 1.2 && < 1.3

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,7 @@ dependencies:
   - lens >= 4.16 && < 6
   - mtl >= 2.1 && < 2.3
   - nanovg >= 0.8 && < 1.0
-  - OpenGL >= 3.0 && < 3.1
+  - OpenGLRaw >= 3.3 && < 3.4
   - process >= 1.6 && < 1.7
   - safe >= 0.3 && < 0.4
   - sdl2 >= 2.5.0 && < 2.6
@@ -83,7 +83,6 @@ executables:
       - -threaded
     dependencies:
       - monomer
-      - text-show >= 3.7 && < 3.10
 
   books:
     main: Main.hs
@@ -93,7 +92,6 @@ executables:
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
-      - text-show >= 3.7 && < 3.10
       - wreq >= 0.5.2 && < 0.6
 
   ticker:
@@ -105,7 +103,6 @@ executables:
       - aeson >= 1.4 && < 2.3
       - monomer
       - scientific >= 0.3 && < 0.4
-      - text-show >= 3.7 && < 3.10
       - websockets >= 0.12 && < 0.13
       - wuss >= 1.1 && < 2.3
 
@@ -117,7 +114,6 @@ executables:
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
-      - text-show >= 3.7 && < 3.10
 
   opengl:
     main: Main.hs
@@ -126,9 +122,7 @@ executables:
       - -threaded
     dependencies:
       - monomer
-      - OpenGLRaw >= 3.3 && < 3.4
       - random >= 1.1 && < 1.3
-      - text-show >= 3.7 && < 3.10
 
   tutorial:
     main: Main.hs
@@ -138,8 +132,6 @@ executables:
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
-      - text-show >= 3.7 && < 3.10
-      - time >= 1.8 && < 1.13
 
 tests:
   monomer-test:

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ dependencies:
   - nanovg >= 0.8 && < 1.0
   - OpenGLRaw >= 3.3 && < 3.4
   - process >= 1.6 && < 1.7
-  - safe >= 0.3 && < 0.4
   - sdl2 >= 2.5.0 && < 2.6
   - stm >= 2.5 && < 2.6
   - text >= 1.2 && < 2.1

--- a/package.yaml
+++ b/package.yaml
@@ -102,7 +102,6 @@ executables:
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
-      - scientific >= 0.3 && < 0.4
       - websockets >= 0.12 && < 0.13
       - wuss >= 1.1 && < 2.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,6 @@ dependencies:
   - text-show >= 3.7 && < 3.10
   - time >= 1.8 && < 1.16
   - transformers >= 0.5 && < 0.7
-  - unordered-containers >= 0.2.8 && < 0.3
   - vector >= 0.12 && < 0.14
   - wreq >= 0.5.2 && < 0.6
 

--- a/src/Monomer/Helper.hs
+++ b/src/Monomer/Helper.hs
@@ -68,3 +68,8 @@ clamp mn mx = max mn . min mx
 -- | Catches any exception thrown by the provided action
 catchAny :: IO a -> (SomeException -> IO a) -> IO a
 catchAny = catch
+
+-- | Returns Just the first item if the list is not empty, Nothing otherwise.
+headMay :: [a] -> Maybe a
+headMay [] = Nothing
+headMay (x : _) = Just x

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -32,9 +32,9 @@ import Data.Maybe
 import Data.Map (Map)
 import Data.List (foldl')
 import Data.Text (Text)
+import Graphics.GL
 
 import qualified Data.Map as Map
-import qualified Graphics.Rendering.OpenGL as GL
 import qualified SDL
 import qualified Data.Sequence as Seq
 
@@ -434,13 +434,10 @@ renderWidgets window dpr renderer clearColor wenv widgetRoot = do
   Size dwW dwH <- getDrawableSize window
   Size vpW vpH <- getViewportSize window dpr
 
-  let position = GL.Position 0 0
-  let size = GL.Size (round dwW) (round dwH)
+  glViewport 0 0 (round dwW) (round dwH)
 
-  GL.viewport GL.$= (position, size)
-
-  GL.clearColor GL.$= clearColor4
-  GL.clear [GL.ColorBuffer]
+  glClearColor r g b a
+  glClear GL_COLOR_BUFFER_BIT
 
   beginFrame renderer vpW vpH
   widgetRender (widgetRoot ^. L.widget) wenv widgetRoot renderer
@@ -459,8 +456,7 @@ renderWidgets window dpr renderer clearColor wenv widgetRoot = do
     r = fromIntegral (clearColor ^. L.r) / 255
     g = fromIntegral (clearColor ^. L.g) / 255
     b = fromIntegral (clearColor ^. L.b) / 255
-    a = clearColor ^. L.a
-    clearColor4 = GL.Color4 r g b (realToFrac a)
+    a = realToFrac (clearColor ^. L.a)
 
 watchWindowResize :: TChan (RenderMsg s e) -> IO ()
 watchWindowResize channel = do

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -39,7 +39,6 @@ import Data.Maybe
 import Data.Sequence (Seq(..), (|>))
 import Data.Text (Text)
 import Data.Typeable (Typeable, typeOf)
-import Safe (headMay)
 import SDL (($=))
 
 import qualified Data.Map as Map
@@ -52,7 +51,7 @@ import qualified SDL.Raw.Types as SDLT
 
 import Monomer.Core
 import Monomer.Event
-import Monomer.Helper (seqStartsWith)
+import Monomer.Helper (headMay, seqStartsWith)
 import Monomer.Main.Types
 import Monomer.Main.Util
 

--- a/src/Monomer/Main/Util.hs
+++ b/src/Monomer/Main/Util.hs
@@ -25,7 +25,6 @@ import Safe (headMay)
 
 import qualified Data.Sequence as Seq
 import qualified Data.Map as Map
-import qualified Graphics.Rendering.OpenGL as GL
 import qualified SDL
 
 import Monomer.Core

--- a/src/Monomer/Main/Util.hs
+++ b/src/Monomer/Main/Util.hs
@@ -21,7 +21,6 @@ import Control.Monad.Extra
 import Control.Monad.State
 import Data.Default
 import Data.Maybe
-import Safe (headMay)
 
 import qualified Data.Sequence as Seq
 import qualified Data.Map as Map
@@ -29,6 +28,7 @@ import qualified SDL
 
 import Monomer.Core
 import Monomer.Event
+import Monomer.Helper (headMay)
 import Monomer.Main.Platform
 import Monomer.Main.Types
 import Monomer.Widgets.Util.Widget

--- a/test/unit/Monomer/Common/CursorIconSpec.hs
+++ b/test/unit/Monomer/Common/CursorIconSpec.hs
@@ -21,7 +21,6 @@ import Data.Default
 import Data.Maybe
 import Data.Sequence (Seq(..))
 import Data.Text (Text)
-import Safe
 import Test.Hspec
 
 import qualified Data.Map.Strict as M
@@ -31,6 +30,7 @@ import Monomer.Core
 import Monomer.Core.Combinators
 import Monomer.Core.Themes.SampleThemes
 import Monomer.Event
+import Monomer.Helper (headMay)
 import Monomer.Main
 import Monomer.TestUtil
 import Monomer.TestEventUtil


### PR DESCRIPTION
Based on the discussion here: https://github.com/fjvallarino/monomer/issues/42

The dependency on `websockets` and `wuss` has not been removed yet, since creating a separate `examples` project makes it harder for users to test and also harder to maintain.

I will look for alternatives in the future.