### PR TITLE
Make Composite's onChange event part of its event queue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@
   in `handleEvent` to know when the model changed. Widgets that want to report model changes to its parent can
   use `Report`/`RequestParent`; an example can be found in `ColorPicker`.
 
+### Removed
+
+- Dependencies on `OpenGL`, `Safe`, `scientific`, `unordered-containers`, `directory`, `HUnit` and `silently`.
+
 ## 1.3.0.0
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,13 @@
+## 1.4.0.0 (in development)
+
+### Changed
+
+- `Composite`'s `onChange` event is now sent to its `handleEvent` function, not to its parent; the type of the
+  generated event was updated to reflect this change. The rationale is that since `onInit` is sent to
+  `handleEvent`, having `onChange` sent to its parent was confusing. At the same time there was not an easy way
+  in `handleEvent` to know when the model changed. Widgets that want to report model changes to its parent can
+  use `Report`/`RequestParent`; an example can be found in `ColorPicker`.
+
 ## 1.3.0.0
 
 ### Added

--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -338,9 +338,17 @@ class CmbIgnoreChildrenEvts t where
 class CmbOnInit t e | t -> e where
   onInit :: e -> t
 
+-- | On init WidgetRequest.
+class CmbOnInitReq t s e | t -> s e where
+  onInitReq :: WidgetRequest s e -> t
+
 -- | On dispose event.
 class CmbOnDispose t e | t -> e where
   onDispose :: e -> t
+
+-- | On dispose WidgetRequest.
+class CmbOnDisposeReq t s e | t -> s e where
+  onDisposeReq :: WidgetRequest s e -> t
 
 -- | On resize event.
 class CmbOnResize t e a | t -> e a where

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -259,7 +259,7 @@ handleResizeWidgets
   -> m (HandlerStep s e)  -- ^ Updated state/"HandlerStep".
 handleResizeWidgets previousStep = do
   windowSize <- use L.windowSize
-  resizeCheckFn <- makeResizeChechFn
+  resizeCheckFn <- makeResizeCheckFn
 
   let viewport = Rect 0 0 (windowSize ^. L.w) (windowSize ^. L.h)
   let (wenv, root, reqs) = previousStep
@@ -276,7 +276,7 @@ handleResizeWidgets previousStep = do
 
   return (wenv2, root2, reqs <> reqs2)
   where
-    makeResizeChechFn = do
+    makeResizeCheckFn = do
       resizeRequests <- use L.resizeRequests
       paths <- mapM getWidgetIdPath resizeRequests
       let parts = Set.fromDistinctAscList . drop 1 . toList . Seq.inits


### PR DESCRIPTION
`Composite`'s `onChange` event is now sent to its `handleEvent` function, not to its parent; the type of the generated event was updated to reflect this change. The rationale is that since `onInit` is sent to `handleEvent`, having `onChange` sent to its parent was confusing. At the same time there was not an easy way in `handleEvent` to know when the model changed.

Widgets that want to report model changes to its parent can use `Report`/`RequestParent`; an example can be found in `ColorPicker`.
