### PR TITLE
Restore previous order of request processing in Composite's mergeChild

### DIFF
--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -941,8 +941,8 @@ mergeChild comp state wenv newModel widgetRoot widgetComp = parentResult where
     _cpsRoot = mergedResult ^. L.node,
     _cpsWidgetKeyMap = collectWidgetKeys M.empty (mergedResult ^. L.node)
   }
-  onChangeReqs = Seq.fromList . catMaybes $
-    fmap (\fn -> toParentReq compWid (fn oldModel)) (_cmpOnChangeReq comp)
+  onChangeReqs = Seq.fromList $
+    mapMaybe (\fn -> toParentReq compWid (fn oldModel)) (_cmpOnChangeReq comp)
   parentReqs = widgetDataSet (_cmpWidgetData comp) newModel
     ++ [ResizeWidgets widgetId | initRequired]
   result = toParentResult comp mergedState wenv widgetComp mergedResult


### PR DESCRIPTION
Restore previous order of request processing in Composite's mergeChild:
- First, child WidgetRequests
- Then, parent WidgetRequests (including the request to update parent model)
- Finally, onChange events (after model is updated).

Under some circumstances, when a parent and child widgets share the model and updates on the child trigger updates on the parent, the parent update could overwrite the changes made by the child.

These changes need a unit test, but I have not been able to create a minimal example that fails with the previous version (although I can reproduce it consistently on an existing application).
