### PR TITLE
When the scroll widget receives focus because of SetFocus/MoveFocus, forward it to the next widget

### DIFF
--- a/src/Monomer/Widgets/Containers/Scroll.hs
+++ b/src/Monomer/Widgets/Containers/Scroll.hs
@@ -484,7 +484,10 @@ makeScroll config state = widget where
       follow = fromMaybe (theme ^. L.scrollFollowFocus) (_scFollowFocus config)
       overlayMatch = focusOverlay == inOverlay (node ^. L.info)
 
+      fwdFocus = Just (resultReqs node [MoveFocus Nothing FocusFwd])
+
       result
+        | target == node ^. L.info . L.path = fwdFocus
         | follow && overlayMatch = focusVp >>= scrollTo wenv node
         | otherwise = Nothing
 


### PR DESCRIPTION
Fixes issue with `textArea` being wrapped by `scroll`, which in turn gets the key assigned by the user causing the focus to be assigned incorrectly.

Discussed here: https://github.com/fjvallarino/monomer/issues/80
