### PR TITLE
Update size req before resizing widgets that requested ResizeWidgets/ResizeWidgetsImmediate

### DIFF
--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -82,7 +82,7 @@ data WidgetData s a
   | WidgetLens (ALens' s a)  -- ^ A lens into the parent model.
 
 {-|
-Widgets instances have an associated path from the root, which is unique at a
+Widget instances have an associated path from the root, which is unique at a
 specific point in time. This path may change, since widgets could be added
 before or after it (for example, a widget is added to the beginning of a list).
 WidgetIds are used by the runtime to create an association from a unique
@@ -641,6 +641,24 @@ data Widget s e =
       -> WidgetNode s e
       -> (SizeReq, SizeReq),
     {-|
+    Sets the preferred size for the widget.
+
+    Arguments:
+
+    - The widget environment.
+    - The widget node.
+    - Helper to check if a given path, or its children, requested updateSizeReq.
+
+    Returns:
+
+    - The result of resizing the widget.
+    -}
+    widgetUpdateSizeReq
+      :: WidgetEnv s e
+      -> WidgetNode s e
+      -> (Path -> Bool)
+      -> WidgetNode s e,
+    {-|
     Resizes the widget to the provided size.
 
     Arguments:
@@ -648,7 +666,7 @@ data Widget s e =
     - The widget environment.
     - The widget node.
     - The new viewport.
-    - Helper to checks if a given path, or its children, requested resize.
+    - Helper to check if a given path, or its children, requested resize.
 
     Returns:
 

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -263,11 +263,12 @@ handleResizeWidgets previousStep = do
 
   let viewport = Rect 0 0 (windowSize ^. L.w) (windowSize ^. L.h)
   let (wenv, root, reqs) = previousStep
+  let newRoot = widgetUpdateSizeReq (root ^. L.widget) wenv root resizeCheckFn
   let newWenv = wenv
         & L.windowSize .~ windowSize
         & L.viewport .~ viewport
-  let rootWidget = root ^. L.widget
-  let newResult = widgetResize rootWidget newWenv root viewport resizeCheckFn
+  let rootWidget = newRoot ^. L.widget
+  let newResult = widgetResize rootWidget newWenv newRoot viewport resizeCheckFn
 
   L.renderRequested .= True
   L.resizeRequests .= Seq.empty

--- a/src/Monomer/Widgets/Single.hs
+++ b/src/Monomer/Widgets/Single.hs
@@ -323,6 +323,7 @@ createSingle state single = Widget {
   widgetHandleEvent = handleEventWrapper single,
   widgetHandleMessage = handleMessageWrapper single,
   widgetGetSizeReq = getSizeReqWrapper single,
+  widgetUpdateSizeReq = updateSizeReqWrapper single,
   widgetResize = resizeHandlerWrapper single,
   widgetRender = renderWrapper single
 }
@@ -563,6 +564,20 @@ handleSizeReqChange single wenv node evt mResult = result where
     | styleChanged || resizeReq = Just $ baseResult
       & L.node .~ updateSizeReq wenv newNode
     | otherwise = mResult
+
+updateSizeReqWrapper
+  :: WidgetModel a
+  => Single s e a
+  -> WidgetEnv s e
+  -> WidgetNode s e
+  -> (Path -> Bool)
+  -> WidgetNode s e
+updateSizeReqWrapper single wenv node resizeReq = newNode where
+  path = node ^. L.info . L.path
+
+  newNode
+    | resizeReq path = updateSizeReq wenv node
+    | otherwise = node
 
 defaultResize :: SingleResizeHandler s e
 defaultResize wenv node viewport = resultNode node


### PR DESCRIPTION
Fix for a non-problem. Code kept around for reference.

When a widget depends on a parent model to determine its size requirements, and this widget happens to update this model somehow, it should request `ResizeWidgets`/`ResizeWidgetsImmediate` during `merge` (this may require keeping a copy of the previous value of the watched property to detect changes). If it requested resize during `handleEvent`/`handleMessage`, its `sizeReq` would be updated immediately before the parent model was updated, and the resulting `sizeReq` would not be the expected.
