### PR TITLE
Give various widgets a readOnly mode

### DIFF
--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -49,6 +49,16 @@ class CmbSelectOnFocus t where
   selectOnFocus = selectOnFocus_ True
   selectOnFocus_ :: Bool -> t
 
+{-|
+Defines whether a widget prevents the user changing the value. Note that, in
+contrast to a disabled widget, a read-only widget can still be focused and
+still allows selecting and copying the value.
+-}
+class CmbReadOnly t where
+  readOnly :: t
+  readOnly = readOnly_ True
+  readOnly_ :: Bool -> t
+
 -- | Defines whether a widget changes its size when the model changes.
 class CmbResizeOnChange t where
   resizeOnChange :: t

--- a/src/Monomer/Widgets/Singles/TextArea.hs
+++ b/src/Monomer/Widgets/Singles/TextArea.hs
@@ -264,7 +264,7 @@ makeTextArea !wdata !config !state = widget where
   !caretMs = fromMaybe defCaretMs (_tacCaretMs config)
   !maxLength = _tacMaxLength config
   !maxLines = _tacMaxLines config
-  !editable = not (fromMaybe False (_tacReadOnly config))
+  !editable = _tacReadOnly config /= Just True
   getModelValue !wenv = widgetDataGet (_weModel wenv) wdata
   -- State
   !currText = _tasText state

--- a/src/Monomer/Widgets/Singles/TextField.hs
+++ b/src/Monomer/Widgets/Singles/TextField.hs
@@ -47,6 +47,7 @@ Configuration options for textField:
   warnings in the UI, or disable buttons if needed.
 - 'resizeOnChange': Whether input causes ResizeWidgets requests.
 - 'selectOnFocus': Whether all input should be selected when focus is received.
+- 'readOnly': Whether to prevent the user changing the input text.
 - 'maxLength': the maximum length of input text.
 - 'textFieldDisplayChar': the character that will be displayed as replacement of
   the real text. Useful for password fields.
@@ -67,6 +68,7 @@ data TextFieldCfg s e = TextFieldCfg {
   _tfcMaxLength :: Maybe Int,
   _tfcResizeOnChange :: Maybe Bool,
   _tfcSelectOnFocus :: Maybe Bool,
+  _tfcReadOnly :: Maybe Bool,
   _tfcOnFocusReq :: [Path -> WidgetRequest s e],
   _tfcOnBlurReq :: [Path -> WidgetRequest s e],
   _tfcOnChangeReq :: [Text -> WidgetRequest s e]
@@ -83,6 +85,7 @@ instance Default (TextFieldCfg s e) where
     _tfcMaxLength = Nothing,
     _tfcResizeOnChange = Nothing,
     _tfcSelectOnFocus = Nothing,
+    _tfcReadOnly = Nothing,
     _tfcOnFocusReq = [],
     _tfcOnBlurReq = [],
     _tfcOnChangeReq = []
@@ -99,6 +102,7 @@ instance Semigroup (TextFieldCfg s e) where
     _tfcMaxLength = _tfcMaxLength t2 <|> _tfcMaxLength t1,
     _tfcResizeOnChange = _tfcResizeOnChange t2 <|> _tfcResizeOnChange t1,
     _tfcSelectOnFocus = _tfcSelectOnFocus t2 <|> _tfcSelectOnFocus t1,
+    _tfcReadOnly = _tfcReadOnly t2 <|> _tfcReadOnly t1,
     _tfcOnFocusReq = _tfcOnFocusReq t1 <> _tfcOnFocusReq t2,
     _tfcOnBlurReq = _tfcOnBlurReq t1 <> _tfcOnBlurReq t2,
     _tfcOnChangeReq = _tfcOnChangeReq t1 <> _tfcOnChangeReq t2
@@ -140,6 +144,11 @@ instance CmbResizeOnChange (TextFieldCfg s e) where
 instance CmbSelectOnFocus (TextFieldCfg s e) where
   selectOnFocus_ sel = def {
     _tfcSelectOnFocus = Just sel
+  }
+
+instance CmbReadOnly (TextFieldCfg s e) where
+  readOnly_ ro = def {
+    _tfcReadOnly = Just ro
   }
 
 instance CmbMaxLength (TextFieldCfg s e) where
@@ -227,6 +236,7 @@ textFieldD_ widgetData configs = inputField where
     _ifcDisplayChar = _tfcDisplayChar config,
     _ifcResizeOnChange = fromMaybe False (_tfcResizeOnChange config),
     _ifcSelectOnFocus = fromMaybe False (_tfcSelectOnFocus config),
+    _ifcReadOnly = fromMaybe False (_tfcReadOnly config),
     _ifcStyle = Just L.textFieldStyle,
     _ifcWheelHandler = Nothing,
     _ifcDragHandler = Nothing,

--- a/test/unit/Monomer/Widgets/Singles/DateFieldSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/DateFieldSpec.hs
@@ -72,6 +72,7 @@ spec = describe "DateField" $ do
   handleEventDate
   handleEventValueDate
   handleEventMouseDragDate
+  handleEventReadOnly
   handleShiftFocus
   getSizeReqDate
   testWidgetType
@@ -246,6 +247,30 @@ handleEventMouseDragDate = describe "handleEventMouseDragDate" $ do
     model es = nodeHandleEventModel wenv es dateNode
     lastIdx es = Seq.index es (Seq.length es - 1)
     lastEvt es = lastIdx (evts es)
+
+handleEventReadOnly :: Spec
+handleEventReadOnly = describe "handleEventReadOnly" $ do
+  it "should ignore text input" $ do
+    let steps = [moveCharR, delCharL, evtT "5"]
+    model steps ^. dateValue `shouldBe` initDate
+  
+  it "should ignore drag" $ do
+    let selStart = Point 5 5
+    let selEnd = Point 100 2000
+    let steps = [evtPress selStart, evtMove selEnd, evtRelease selEnd]
+    model steps ^. dateValue `shouldBe` initDate
+
+  it "should ignore wheel" $ do
+    let steps = [WheelScroll (Point 100 10) (Point 0 (-2000)) WheelNormal]
+    model steps ^. dateValue `shouldBe` initDate
+
+  where
+    initDate = fromGregorian 1999 11 21
+    wenv = mockWenv (DateModel initDate True)
+      & L.inputStatus . L.keyMod . L.leftShift .~ True
+    dateCfg = [readOnly :: DateFieldCfg DateModel TestEvt Day]
+    dateNode = dateField_ dateValue dateCfg
+    model es = nodeHandleEventModel wenv es dateNode
 
 handleShiftFocus :: Spec
 handleShiftFocus = describe "handleShiftFocus" $ do

--- a/test/unit/Monomer/Widgets/Singles/NumericFieldSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/NumericFieldSpec.hs
@@ -65,6 +65,7 @@ specIntegral = describe "IntegralField" $ do
   handleEventIntegral
   handleEventValueIntegral
   handleEventMouseDragIntegral
+  handleEventReadOnly
   getSizeReqIntegral
   testIntegralWidgetType
 
@@ -475,6 +476,30 @@ handleShiftFocusFractional = describe "handleShiftFocusFractional" $ do
         numericField_ fractionalValue [wheelRate 1, onFocus GotFocus]
       ]
     evts es = nodeHandleEventEvts wenv es floatNode
+
+handleEventReadOnly :: Spec
+handleEventReadOnly = describe "handleEventReadOnly" $ do
+  it "should ignore text input" $ do
+    let steps = [moveCharR, delCharL, evtT "5"]
+    model steps ^. fractionalValue `shouldBe` initValue
+  
+  it "should ignore drag" $ do
+    let selStart = Point 5 5
+    let selEnd = Point 100 2000
+    let steps = [evtPress selStart, evtMove selEnd, evtRelease selEnd]
+    model steps ^. fractionalValue `shouldBe` initValue
+
+  it "should ignore wheel" $ do
+    let steps = [WheelScroll (Point 100 10) (Point 0 (-2000)) WheelNormal]
+    model steps ^. fractionalValue `shouldBe` initValue
+
+  where
+    initValue = Just 42.4
+    wenv = mockWenv (FractionalModel initValue False)
+      & L.inputStatus . L.keyMod . L.leftShift .~ True
+    fieldCfg = [readOnly :: NumericFieldCfg FractionalModel TestEvt (Maybe Double)]
+    fieldNode = numericField_ fractionalValue fieldCfg
+    model es = nodeHandleEventModel wenv es fieldNode
 
 getSizeReqFractional :: Spec
 getSizeReqFractional = describe "getSizeReqFractional" $ do

--- a/test/unit/Monomer/Widgets/Singles/TextAreaSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/TextAreaSpec.hs
@@ -51,6 +51,7 @@ spec = describe "TextArea" $ do
   handleEventValue
   handleEventMouseSelect
   handleEventHistory
+  handleEventReadOnly
   getSizeReq
 
 handleEvent :: Spec
@@ -322,6 +323,24 @@ handleEventHistory = describe "handleEventHistory" $ do
     evts es = nodeHandleEventEvts wenv es txtNode
     lastIdx es = Seq.index es (Seq.length es - 1)
     lastEvt es = lastIdx (evts es)
+
+handleEventReadOnly :: Spec
+handleEventReadOnly = describe "handleEventReadOnly" $ do
+  it "should ignore text input" $ do
+    model [evtT "a"] ^. textValue `shouldBe` initText
+  
+  it "should ignore cut" $ do
+    model [selWordR, evtKG keyX] ^. textValue `shouldBe` initText
+  
+  it "should ignore paste" $ do
+    model [selWordR, evtKG keyV] ^. textValue `shouldBe` initText
+  
+  where
+    initText = "hello"
+    wenv = mockWenv (TestModel initText)
+    txtCfg = [readOnly :: TextAreaCfg TestModel TestEvt]
+    txtNode = textArea_ textValue txtCfg
+    model es = nodeHandleEventModel wenv es txtNode
 
 getSizeReq :: Spec
 getSizeReq = describe "getSizeReq" $ do

--- a/test/unit/Monomer/Widgets/Singles/TextFieldSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/TextFieldSpec.hs
@@ -53,6 +53,7 @@ spec = describe "TextField" $ do
   handleEventHistory
   handleEventMouseDrag
   handleEventWheel
+  handleEventReadOnly
   getSizeReq
 
 handleEvent :: Spec
@@ -293,6 +294,24 @@ handleEventWheel = describe "handleEventWheel" $ do
   where
     wenv = mockWenvEvtUnit (TestModel "")
     model es = nodeHandleEventModel wenv es (textField textValue)
+
+handleEventReadOnly :: Spec
+handleEventReadOnly = describe "handleEventReadOnly" $ do
+  it "should ignore text input" $ do
+    model [evtT "a"] ^. textValue `shouldBe` initText
+  
+  it "should ignore cut" $ do
+    model [selWordR, evtKG keyX] ^. textValue `shouldBe` initText
+  
+  it "should ignore paste" $ do
+    model [selWordR, evtKG keyV] ^. textValue `shouldBe` initText
+  
+  where
+    initText = "hello"
+    wenv = mockWenv (TestModel initText)
+    txtCfg = [readOnly :: TextFieldCfg TestModel TestEvt]
+    txtNode = textField_ textValue txtCfg
+    model es = nodeHandleEventModel wenv es txtNode
 
 getSizeReq :: Spec
 getSizeReq = describe "getSizeReq" $ do

--- a/test/unit/Monomer/Widgets/Singles/TimeFieldSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/TimeFieldSpec.hs
@@ -72,6 +72,7 @@ spec = describe "TimeField" $ do
   handleEventTime
   handleEventValueTime
   handleEventMouseDragTime
+  handleEventReadOnly
   handleShiftFocus
   getSizeReqTime
   testWidgetType
@@ -255,6 +256,30 @@ handleEventMouseDragTime = describe "handleEventMouseDragTime" $ do
     model es = nodeHandleEventModel wenv es timeNode
     lastIdx es = Seq.index es (Seq.length es - 1)
     lastEvt es = lastIdx (evts es)
+
+handleEventReadOnly :: Spec
+handleEventReadOnly = describe "handleEventReadOnly" $ do
+  it "should ignore text input" $ do
+    let steps = [moveCharR, delCharL, evtT "5"]
+    model steps ^. timeValue `shouldBe` initTime
+  
+  it "should ignore drag" $ do
+    let selStart = Point 5 5
+    let selEnd = Point 100 2000
+    let steps = [evtPress selStart, evtMove selEnd, evtRelease selEnd]
+    model steps ^. timeValue `shouldBe` initTime
+
+  it "should ignore wheel" $ do
+    let steps = [WheelScroll (Point 100 10) (Point 0 (-2000)) WheelNormal]
+    model steps ^. timeValue `shouldBe` initTime
+  
+  where
+    initTime = TimeOfDay 20 37 00
+    wenv = mockWenv (TimeModel initTime False)
+      & L.inputStatus . L.keyMod . L.leftShift .~ True
+    timeCfg = [readOnly :: TimeFieldCfg TimeModel TestEvt TimeOfDay]
+    timeNode = timeField_ timeValue timeCfg
+    model es = nodeHandleEventModel wenv es timeNode
 
 handleShiftFocus :: Spec
 handleShiftFocus = describe "handleShiftFocus" $ do


### PR DESCRIPTION
This mode allows text to be selected (and copied), but does not allow
editing. See issue #87