### PR TITLE
Do not detect Fixed fields as Integral in numericField. If decimals config is set, make it take precedence over detected type

### DIFF
--- a/.ghcid
+++ b/.ghcid
@@ -1,3 +1,3 @@
---command "stack repl --main-is monomer:exe:todo"
+--command "stack repl --main-is monomer:exe:tutorial"
 --test ":main"
 --restart=package.yaml

--- a/src/Monomer/Widgets/Singles/NumericField.hs
+++ b/src/Monomer/Widgets/Singles/NumericField.hs
@@ -310,9 +310,11 @@ numericFieldD_ widgetData configs = newNode where
     | isJust minVal = fromJust minVal
     | isJust maxVal = fromJust maxVal
     | otherwise = numericFromFractional 0
-  decimals
-    | isIntegral initialValue = 0
-    | otherwise = max 0 $ fromMaybe 2 (_nfcDecimals config)
+  decimals = case _nfcDecimals config of
+    Just count -> max 0 count
+    Nothing
+      | isIntegral initialValue -> 0
+      | otherwise -> 2
   defWidth
     | isIntegral initialValue = 50
     | otherwise = 70
@@ -438,7 +440,6 @@ numberInBounds (Just minVal) (Just maxVal) val = val >= minVal && val <= maxVal
 isIntegral :: Typeable a => a -> Bool
 isIntegral val
   | "Int" `isPrefixOf` name = True
-  | "Fixed" `isPrefixOf` name = True
   | "Word" `isPrefixOf` name = True
   | otherwise = False
   where


### PR DESCRIPTION
The `Data.Fixed` types are not integers and should not be treated as such by default.

The `decimals` config option should take precedence over the detected data type.