### PR TITLE
Fix optics tutorial sample code

### DIFF
--- a/docs/tutorials/external/01-optics.md
+++ b/docs/tutorials/external/01-optics.md
@@ -64,6 +64,7 @@ data Address = Address {
 
 data Person = Person {
   _name :: Text,
+  _homeAddress :: Address,
   _address :: Maybe Address,
   _friends :: [Person]
 } deriving (Eq, Show)


### PR DESCRIPTION
I believe this line was missing in the sample code. Otherwise the sample code

```
person1 = Person "Mark" address1 Nothing []
person2 = Person "Jane" address2 (Just address3) [person1]
person3 = Person "Zack" address3 Nothing []
```
and 
```
print $ person1 ^. homeAddress . doorNumber
```

would not work.