### PR TITLE
Add appStartTs to WidgetEnv. Make Timestamp a newtype

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 - Support for breaking text lines at character boundaries ([PR #86](https://github.com/fjvallarino/monomer/pull/86)). Thanks @toku-sa-n!
 - Read-only mode for `textField`, `numericField`, `dateField`, `timeField` and `textArea` ([PR #93](https://github.com/fjvallarino/monomer/pull/93)). Thanks @Dretch!
 - The `scroll` widget now supports a `thumbMinSize` configuration option that allows setting a minimum thumb size ([PR #100](https://github.com/fjvallarino/monomer/pull/100)).
+- New field to `WidgetEnv`, `_weAppStartTs`, representing the time in milliseconds when the application started. Complementary to `_weTimestamp` ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 
 ### Changed
 
@@ -21,6 +22,7 @@
   in `handleEvent` to know when the model changed. Widgets that want to report model changes to its parent can
   use `Report`/`RequestParent`; an example can be found in `ColorPicker` ([PR #71](https://github.com/fjvallarino/monomer/pull/71)).
 - The `keystroke` widget now supports the `Backspace` key ([PR #74](https://github.com/fjvallarino/monomer/pull/74)).
+- `Timestamp` is now a newtype. Enforce use of this type instead of `Int` when appropriate ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 
 ### Renamed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@
 - Support for breaking text lines at character boundaries ([PR #86](https://github.com/fjvallarino/monomer/pull/86)). Thanks @toku-sa-n!
 - Read-only mode for `textField`, `numericField`, `dateField`, `timeField` and `textArea` ([PR #93](https://github.com/fjvallarino/monomer/pull/93)). Thanks @Dretch!
 - The `scroll` widget now supports a `thumbMinSize` configuration option that allows setting a minimum thumb size ([PR #100](https://github.com/fjvallarino/monomer/pull/100)).
-- New field to `WidgetEnv`, `_weAppStartTs`, representing the time in milliseconds when the application started. Complementary to `_weTimestamp` ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
+- New field `_weAppStartTs` in `WidgetEnv`, complementary to `_weTimestamp`, representing the time in milliseconds when the application started. Added utility function `currentTimeMs` that returns their sum with a polymorphic type ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 
 ### Changed
 

--- a/examples/todo/Main.hs
+++ b/examples/todo/Main.hs
@@ -221,7 +221,7 @@ handleEvent wenv node model evt = case evt of
 addNewTodo :: WidgetEnv s e -> TodoModel -> TodoModel
 addNewTodo wenv model = newModel where
   newTodo = model ^. activeTodo
-    & todoId .~ wenv ^. L.timestamp
+    & todoId .~ currentTimeMs wenv
   newModel = model
     & todos .~ (newTodo : model ^. todos)
 

--- a/examples/todo/TodoTypes.hs
+++ b/examples/todo/TodoTypes.hs
@@ -31,7 +31,7 @@ data TodoStatus
   deriving (Eq, Show, Enum)
 
 data Todo = Todo {
-  _todoId :: Int,
+  _todoId :: Timestamp,
   _todoType :: TodoType,
   _status :: TodoStatus,
   _description :: Text

--- a/examples/tutorial/Tutorial03_LifeCycle.hs
+++ b/examples/tutorial/Tutorial03_LifeCycle.hs
@@ -59,7 +59,8 @@ buildUI wenv model = widgetTree where
       keystroke [("Enter", AddItem)] $ hstack [
         label "Description:",
         spacer,
-        textField_ newItemText [placeholder "Write here!"], -- `nodeKey` "description",
+        textField_ newItemText [placeholder "Write here!"]
+          `nodeKey` "description",
         spacer,
         button "Add" AddItem
           `styleBasic` [paddingH 5]

--- a/examples/tutorial/Tutorial03_LifeCycle.hs
+++ b/examples/tutorial/Tutorial03_LifeCycle.hs
@@ -89,7 +89,7 @@ handleEvent wenv node model evt = case evt of
     & items .~ removeIdx idx (model ^. items)]
   _ -> []
   where
-    newItem = ListItem (wenv ^. L.timestamp) (model ^. newItemText)
+    newItem = ListItem (currentTimeMs wenv) (model ^. newItemText)
 
 removeIdx :: Int -> [a] -> [a]
 removeIdx idx lst = part1 ++ drop 1 part2 where

--- a/examples/tutorial/Tutorial03_LifeCycle.hs
+++ b/examples/tutorial/Tutorial03_LifeCycle.hs
@@ -22,7 +22,7 @@ import qualified Data.Text as T
 import qualified Monomer.Lens as L
 
 data ListItem = ListItem {
-  _ts :: Int,
+  _ts :: Timestamp,
   _text :: Text
 } deriving (Eq, Show)
 

--- a/src/Monomer/Core/Util.hs
+++ b/src/Monomer/Core/Util.hs
@@ -333,6 +333,14 @@ isResizeAnyResult res = isResizeResult res || isResizeImmediateResult res
 isMacOS :: WidgetEnv s e -> Bool
 isMacOS wenv = _weOs wenv == "Mac OS X"
 
+{-|
+Returns the current time in milliseconds. Adds appStartTs and timestamp fields
+from 'WidgetEnv' and converts the result to the expected 'Integral' type.
+-}
+currentTimeMs :: Integral a => WidgetEnv s e -> a
+currentTimeMs wenv = fromIntegral ts where
+  ts = wenv ^. L.appStartTs + wenv ^. L.timestamp
+
 -- | Returns a string description of a node and its children.
 widgetTreeDesc :: Int -> WidgetNode s e -> String
 widgetTreeDesc level node = desc where

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -94,8 +94,8 @@ Several WidgetRequests rely on this to find the destination of asynchronous
 requests (tasks, clipboard, etc).
 -}
 data WidgetId = WidgetId {
-  _widTs :: Int,    -- ^ The timestamp when the instance was created.
-  _widPath :: Path  -- ^ The path at creation time.
+  _widTs :: Timestamp,  -- ^ The timestamp when the instance was created.
+  _widPath :: Path      -- ^ The path at creation time.
 } deriving (Eq, Show, Ord, Generic)
 
 instance Default WidgetId where
@@ -192,7 +192,7 @@ data WidgetRequest s e
   | RenderOnce
   -- | Useful if a widget requires periodic rendering. An optional maximum
   --   number of frames can be provided.
-  | RenderEvery WidgetId Int (Maybe Int)
+  | RenderEvery WidgetId Timestamp (Maybe Int)
   -- | Stops a previous periodic rendering request.
   | RenderStop WidgetId
   {-|
@@ -293,6 +293,8 @@ data WidgetEnv s e = WidgetEnv {
   _weOs :: Text,
   -- | Device pixel rate.
   _weDpr :: Double,
+  -- | The timestamp in milliseconds when the application started.
+  _weAppStartTs :: Timestamp,
   -- | Provides helper funtions for calculating text size.
   _weFontManager :: FontManager,
   -- | Returns the node info, and its parents', given a path from root.
@@ -325,7 +327,10 @@ data WidgetEnv s e = WidgetEnv {
   _weModel :: s,
   -- | The input status, mainly mouse and keyboard.
   _weInputStatus :: InputStatus,
-  -- | The timestamp when this cycle started.
+  {-|
+  The timestamp in milliseconds when this event/message cycle started. This
+  value starts from zero each time the application is executed.
+  -}
   _weTimestamp :: Timestamp,
   {-|
   Whether the theme changed in this cycle. Should be considered when a widget

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -11,6 +11,7 @@ Basic types and definitions for Widgets.
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# Language GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Strict #-}
 
@@ -24,7 +25,9 @@ import Data.Sequence (Seq)
 import Data.String (IsString(..))
 import Data.Text (Text)
 import Data.Typeable (Typeable, typeOf)
+import Data.Word (Word64)
 import GHC.Generics
+import TextShow
 
 import qualified Data.Text as T
 
@@ -34,8 +37,15 @@ import Monomer.Core.ThemeTypes
 import Monomer.Event.Types
 import Monomer.Graphics.Types
 
--- | Time ellapsed since startup
-type Timestamp = Int
+{-|
+Timestamp in milliseconds. Useful for representing the time of events, ellapsed
+time since start/start time of the application and length of intervals.
+
+It can be converted from/to other numeric types using the standard functions.
+-}
+newtype Timestamp = Timestamp {
+  unTimestamp :: Word64
+} deriving (Show, Eq, Ord, Num, Enum, Bounded, Real, Integral, TextShow)
 
 -- | Type constraints for a valid model
 type WidgetModel s = Typeable s
@@ -329,7 +339,7 @@ data WidgetEnv s e = WidgetEnv {
   _weInputStatus :: InputStatus,
   {-|
   The timestamp in milliseconds when this event/message cycle started. This
-  value starts from zero each time the application is executed.
+  value starts from zero each time the application is run.
   -}
   _weTimestamp :: Timestamp,
   {-|

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -32,7 +32,8 @@ import Data.Maybe
 import Data.Map (Map)
 import Data.List (foldl')
 import Data.Text (Text)
-import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Time
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Graphics.GL
 
 import qualified Data.Map as Map
@@ -142,8 +143,9 @@ runAppLoop window glCtx channel widgetRoot config = do
   let exitEvents = _apcExitEvent config
   let mainBtn = fromMaybe BtnLeft (_apcMainButton config)
   let contextBtn = fromMaybe BtnRight (_apcContextButton config)
+  let toMs = floor . (1e3 *) . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
 
-  appStartTs <- round . (3 *) <$> liftIO getPOSIXTime
+  appStartTs <- toMs <$> liftIO getCurrentTime
   startTs <- fmap fromIntegral SDL.ticks
 
   model <- use L.mainModel
@@ -193,7 +195,7 @@ runAppLoop window glCtx channel widgetRoot config = do
     _mlRenderer = renderer,
     _mlTheme = theme,
     _mlMaxFps = maxFps,
-    _mlAppStartTs = 0,
+    _mlAppStartTs = appStartTs,
     _mlLatestRenderTs = 0,
     _mlFrameStartTs = startTs,
     _mlFrameAccumTs = 0,

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -517,7 +517,7 @@ handleRenderOnce previousStep = do
 handleRenderEvery
   :: MonomerM s e m
   => WidgetId
-  -> Int
+  -> Timestamp
   -> Maybe Int
   -> HandlerStep s e
   -> m (HandlerStep s e)

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -59,8 +59,8 @@ be provided.
 -}
 data RenderSchedule = RenderSchedule {
   _rsWidgetId :: WidgetId,
-  _rsStart :: Int,
-  _rsMs :: Int,
+  _rsStart :: Timestamp,
+  _rsMs :: Timestamp,
   _rsRepeat :: Maybe Int
 } deriving (Eq, Show, Generic)
 

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -54,7 +54,7 @@ Configuration options for fade:
 -}
 data FadeCfg e = FadeCfg {
   _fdcAutoStart :: Maybe Bool,
-  _fdcDuration :: Maybe Int,
+  _fdcDuration :: Maybe Timestamp,
   _fdcOnFinished :: [e]
 } deriving (Eq, Show)
 
@@ -80,7 +80,7 @@ instance CmbAutoStart (FadeCfg e) where
     _fdcAutoStart = Just start
   }
 
-instance CmbDuration (FadeCfg e) Int where
+instance CmbDuration (FadeCfg e) Timestamp where
   duration dur = def {
     _fdcDuration = Just dur
   }
@@ -92,7 +92,7 @@ instance CmbOnFinished (FadeCfg e) e where
 
 data FadeState = FadeState {
   _fdsRunning :: Bool,
-  _fdsStartTs :: Int
+  _fdsStartTs :: Timestamp
 } deriving (Eq, Show, Generic)
 
 instance Default FadeState where
@@ -141,7 +141,7 @@ makeFade isFadeIn config state = widget where
   autoStart = fromMaybe False (_fdcAutoStart config)
   duration = fromMaybe 500 (_fdcDuration config)
   period = 20
-  steps = duration `div` period
+  steps = fromIntegral $ duration `div` period
 
   finishedReq node = delayedMessage node AnimationFinished duration
   renderReq wenv node = req where

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -66,7 +66,7 @@ Configuration options for slide:
 data SlideCfg e = SlideCfg {
   _slcDirection :: Maybe SlideDirection,
   _slcAutoStart :: Maybe Bool,
-  _slcDuration :: Maybe Int,
+  _slcDuration :: Maybe Timestamp,
   _slcOnFinished :: [e]
 } deriving (Eq, Show)
 
@@ -94,7 +94,7 @@ instance CmbAutoStart (SlideCfg e) where
     _slcAutoStart = Just start
   }
 
-instance CmbDuration (SlideCfg e) Int where
+instance CmbDuration (SlideCfg e) Timestamp where
   duration dur = def {
     _slcDuration = Just dur
   }
@@ -122,7 +122,7 @@ slideBottom = def { _slcDirection = Just SlideDown }
 
 data SlideState = SlideState {
   _slsRunning :: Bool,
-  _slsStartTs :: Int
+  _slsStartTs :: Timestamp
 } deriving (Eq, Show, Generic)
 
 instance Default SlideState where
@@ -174,7 +174,7 @@ makeSlide isSlideIn config state = widget where
   autoStart = fromMaybe False (_slcAutoStart config)
   duration = fromMaybe 500 (_slcDuration config)
   period = 20
-  steps = duration `div` period
+  steps = fromIntegral $ duration `div` period
 
   finishedReq node = delayedMessage node AnimationFinished duration
   renderReq wenv node = req where

--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -1016,6 +1016,7 @@ convertWidgetEnv :: WidgetEnv sp ep -> WidgetKeyMap s e -> s -> WidgetEnv s e
 convertWidgetEnv wenv widgetKeyMap model = WidgetEnv {
   _weOs = _weOs wenv,
   _weDpr = _weDpr wenv,
+  _weAppStartTs = _weAppStartTs wenv,
   _weFontManager = _weFontManager wenv,
   _weFindBranchByPath = _weFindBranchByPath wenv,
   _weMainButton = _weMainButton wenv,

--- a/src/Monomer/Widgets/Containers/Tooltip.hs
+++ b/src/Monomer/Widgets/Containers/Tooltip.hs
@@ -51,7 +51,7 @@ Configuration options for tooltip:
 - 'tooltipFollow': if, after tooltip is displayed, it should follow the mouse.
 -}
 data TooltipCfg = TooltipCfg {
-  _ttcDelay :: Maybe Int,
+  _ttcDelay :: Maybe Timestamp,
   _ttcFollowCursor :: Maybe Bool,
   _ttcMaxWidth :: Maybe Double,
   _ttcMaxHeight :: Maybe Double
@@ -87,7 +87,7 @@ instance CmbMaxHeight TooltipCfg where
   }
 
 -- | Delay before the tooltip is displayed when child widget is hovered.
-tooltipDelay :: Int -> TooltipCfg
+tooltipDelay :: Timestamp -> TooltipCfg
 tooltipDelay ms = def {
   _ttcDelay = Just ms
 }
@@ -100,7 +100,7 @@ tooltipFollow = def {
 
 data TooltipState = TooltipState {
   _ttsLastPos :: Point,
-  _ttsLastPosTs :: Int
+  _ttsLastPosTs :: Timestamp
 } deriving (Eq, Show, Generic)
 
 -- | Creates a tooltip for the child widget.

--- a/src/Monomer/Widgets/Singles/Base/InputField.hs
+++ b/src/Monomer/Widgets/Singles/Base/InputField.hs
@@ -97,7 +97,7 @@ data InputFieldCfg s e a = InputFieldCfg {
   -- | Caret width.
   _ifcCaretWidth :: Maybe Double,
   -- | Caret blink period.
-  _ifcCaretMs :: Maybe Int,
+  _ifcCaretMs :: Maybe Timestamp,
   -- | Character to display as text replacement. Useful for passwords.
   _ifcDisplayChar :: Maybe Char,
   -- | Whether input causes ResizeWidgets requests. Defaults to False.
@@ -186,7 +186,7 @@ data InputFieldState a = InputFieldState {
   -- | Current index into history.
   _ifsHistIdx :: Int,
   -- | The timestamp when focus was received (used for caret blink)
-  _ifsFocusStart :: Int
+  _ifsFocusStart :: Timestamp
 } deriving (Eq, Show, Typeable, Generic)
 
 initialState :: a -> InputFieldState a
@@ -209,7 +209,7 @@ initialState value = InputFieldState {
 defCaretW :: Double
 defCaretW = 2
 
-defCaretMs :: Int
+defCaretMs :: Timestamp
 defCaretMs = 500
 
 -- | Creates an instance of an input field, with customizations in config.

--- a/src/Monomer/Widgets/Singles/DateField.hs
+++ b/src/Monomer/Widgets/Singles/DateField.hs
@@ -153,7 +153,7 @@ Configuration options for dateField:
 -}
 data DateFieldCfg s e a = DateFieldCfg {
   _dfcCaretWidth :: Maybe Double,
-  _dfcCaretMs :: Maybe Int,
+  _dfcCaretMs :: Maybe Timestamp,
   _dfcValid :: Maybe (WidgetData s Bool),
   _dfcValidV :: [Bool -> e],
   _dfcDateDelim :: Maybe Char,
@@ -218,7 +218,7 @@ instance CmbCaretWidth (DateFieldCfg s e a) Double where
     _dfcCaretWidth = Just w
   }
 
-instance CmbCaretMs (DateFieldCfg s e a) Int where
+instance CmbCaretMs (DateFieldCfg s e a) Timestamp where
   caretMs ms = def {
     _dfcCaretMs = Just ms
   }

--- a/src/Monomer/Widgets/Singles/Label.hs
+++ b/src/Monomer/Widgets/Singles/Label.hs
@@ -142,7 +142,7 @@ data LabelState = LabelState {
   _lstTextStyle :: Maybe TextStyle,
   _lstTextRect :: Rect,
   _lstTextLines :: Seq TextLine,
-  _lstPrevResize :: (Int, Bool)
+  _lstPrevResize :: (Timestamp, Bool)
 } deriving (Eq, Show, Generic)
 
 -- | Creates a label using the provided 'Text'.

--- a/src/Monomer/Widgets/Singles/NumericField.hs
+++ b/src/Monomer/Widgets/Singles/NumericField.hs
@@ -124,7 +124,7 @@ Configuration options for numericField:
 -}
 data NumericFieldCfg s e a = NumericFieldCfg {
   _nfcCaretWidth :: Maybe Double,
-  _nfcCaretMs :: Maybe Int,
+  _nfcCaretMs :: Maybe Timestamp,
   _nfcValid :: Maybe (WidgetData s Bool),
   _nfcValidV :: [Bool -> e],
   _nfcDecimals :: Maybe Int,
@@ -186,7 +186,7 @@ instance CmbCaretWidth (NumericFieldCfg s e a) Double where
     _nfcCaretWidth = Just w
   }
 
-instance CmbCaretMs (NumericFieldCfg s e a) Int where
+instance CmbCaretMs (NumericFieldCfg s e a) Timestamp where
   caretMs ms = def {
     _nfcCaretMs = Just ms
   }

--- a/src/Monomer/Widgets/Singles/TextArea.hs
+++ b/src/Monomer/Widgets/Singles/TextArea.hs
@@ -50,7 +50,7 @@ import qualified Monomer.Lens as L
 defCaretW :: Double
 defCaretW = 2
 
-defCaretMs :: Int
+defCaretMs :: Timestamp
 defCaretMs = 500
 
 {-|
@@ -71,7 +71,7 @@ Configuration options for textArea:
 -}
 data TextAreaCfg s e = TextAreaCfg {
   _tacCaretWidth :: Maybe Double,
-  _tacCaretMs :: Maybe Int,
+  _tacCaretMs :: Maybe Timestamp,
   _tacMaxLength :: Maybe Int,
   _tacMaxLines :: Maybe Int,
   _tacAcceptTab :: Maybe Bool,
@@ -118,7 +118,7 @@ instance CmbCaretWidth (TextAreaCfg s e) Double where
     _tacCaretWidth = Just w
   }
 
-instance CmbCaretMs (TextAreaCfg s e) Int where
+instance CmbCaretMs (TextAreaCfg s e) Timestamp where
   caretMs ms = def {
     _tacCaretMs = Just ms
   }
@@ -193,7 +193,7 @@ data TextAreaState = TextAreaState {
   _tasTextLines :: Seq TextLine,
   _tasHistory :: Seq HistoryStep,
   _tasHistoryIdx :: Int,
-  _tasFocusStart :: Int
+  _tasFocusStart :: Timestamp
 } deriving (Eq, Show, Generic)
 
 instance Default TextAreaState where

--- a/src/Monomer/Widgets/Singles/TextField.hs
+++ b/src/Monomer/Widgets/Singles/TextField.hs
@@ -60,7 +60,7 @@ Configuration options for textField:
 -}
 data TextFieldCfg s e = TextFieldCfg {
   _tfcCaretWidth :: Maybe Double,
-  _tfcCaretMs :: Maybe Int,
+  _tfcCaretMs :: Maybe Timestamp,
   _tfcDisplayChar :: Maybe Char,
   _tfcPlaceholder :: Maybe Text,
   _tfcValid :: Maybe (WidgetData s Bool),
@@ -116,7 +116,7 @@ instance CmbCaretWidth (TextFieldCfg s e) Double where
     _tfcCaretWidth = Just w
   }
 
-instance CmbCaretMs (TextFieldCfg s e) Int where
+instance CmbCaretMs (TextFieldCfg s e) Timestamp where
   caretMs ms = def {
     _tfcCaretMs = Just ms
   }

--- a/src/Monomer/Widgets/Singles/TimeField.hs
+++ b/src/Monomer/Widgets/Singles/TimeField.hs
@@ -147,7 +147,7 @@ warnings in the UI, or disable buttons if needed.
 -}
 data TimeFieldCfg s e a = TimeFieldCfg {
   _tfcCaretWidth :: Maybe Double,
-  _tfcCaretMs :: Maybe Int,
+  _tfcCaretMs :: Maybe Timestamp,
   _tfcValid :: Maybe (WidgetData s Bool),
   _tfcValidV :: [Bool -> e],
   _tfcTimeFormat :: Maybe TimeFormat,
@@ -209,7 +209,7 @@ instance CmbCaretWidth (TimeFieldCfg s e a) Double where
     _tfcCaretWidth = Just w
   }
 
-instance CmbCaretMs (TimeFieldCfg s e a) Int where
+instance CmbCaretMs (TimeFieldCfg s e a) Timestamp where
   caretMs ms = def {
     _tfcCaretMs = Just ms
   }

--- a/src/Monomer/Widgets/Util/Widget.hs
+++ b/src/Monomer/Widgets/Util/Widget.hs
@@ -202,14 +202,14 @@ handleWidgetIdChange oldNode result = newResult where
     | otherwise = result
 
 -- | Sends a message to the given node with a delay of n ms.
-delayedMessage :: Typeable i => WidgetNode s e -> i -> Int -> WidgetRequest s e
+delayedMessage :: Typeable i => WidgetNode s e -> i -> Timestamp -> WidgetRequest s e
 delayedMessage node msg delay = delayedMessage_ widgetId path msg delay where
   widgetId = node ^. L.info . L.widgetId
   path = node ^. L.info . L.path
 
 -- | Sends a message to the given WidgetId with a delay of n ms.
 delayedMessage_
-  :: Typeable i => WidgetId -> Path -> i -> Int -> WidgetRequest s e
+  :: Typeable i => WidgetId -> Path -> i -> Timestamp -> WidgetRequest s e
 delayedMessage_ widgetId path msg delay = RunTask widgetId path $ do
-  threadDelay (delay * 1000)
+  threadDelay (fromIntegral delay * 1000)
   return msg

--- a/test/unit/Monomer/TestUtil.hs
+++ b/test/unit/Monomer/TestUtil.hs
@@ -163,6 +163,7 @@ mockWenv :: s -> WidgetEnv s e
 mockWenv model = WidgetEnv {
   _weOs = "Mac OS X",
   _weDpr = 2,
+  _weAppStartTs = 0,
   _weFontManager = mockFontManager,
   _weFindBranchByPath = const Seq.empty,
   _weMainButton = BtnLeft,


### PR DESCRIPTION
`WidgetEnv`'s timestamp field starts from zero every time the application is run, but sometimes it's useful to have the complete UNIX timestamp. To account for this, the `_weAppStartTs` field was added.

All the places that rely on timestamps have been updated to use the `Timestamp` type instead of `Int`. To improve type safety, `Timestamp` has been turned into a newtype.