### PR TITLE
Make style... family of functions combine styles instead of replacing them. Add style...Set family of functions.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 - Read-only mode for `textField`, `numericField`, `dateField`, `timeField` and `textArea` ([PR #93](https://github.com/fjvallarino/monomer/pull/93)). Thanks @Dretch!
 - The `scroll` widget now supports a `thumbMinSize` configuration option that allows setting a minimum thumb size ([PR #100](https://github.com/fjvallarino/monomer/pull/100)).
 - New field `_weAppStartTs` in `WidgetEnv`, complementary to `_weTimestamp`, representing the time in milliseconds when the application started. Added utility function `currentTimeMs` that returns their sum with a polymorphic type ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
+- `style...Set` family of functions ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
 
 ### Changed
 
@@ -23,6 +24,7 @@
   use `Report`/`RequestParent`; an example can be found in `ColorPicker` ([PR #71](https://github.com/fjvallarino/monomer/pull/71)).
 - The `keystroke` widget now supports the `Backspace` key ([PR #74](https://github.com/fjvallarino/monomer/pull/74)).
 - `Timestamp` is now a newtype. Enforce use of this type instead of `Int` when appropriate ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
+- `style...` family of functions now combine new attributes with the existing ones ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
 
 ### Renamed
 

--- a/docs/tutorials/00-setup.md
+++ b/docs/tutorials/00-setup.md
@@ -27,12 +27,15 @@ brew install glew
 
 #### Notes
 
-Currently Monomer fails to compile on M1 Macs. This issue should be fixed when
-GHC 9.2 is released, since it will include a native code generator for that CPU.
+The standard build process currently fails on M1 Macs. This issue should be
+fixed when support for `GHC 9.2` is added to `stack`, since that version of GHC
+includes a native code generator for M1 processors.
 
-Until that time, it has been [reported](https://github.com/fjvallarino/monomer/issues/1#issuecomment-914866110)
-that building for x86 and running the application in the Rosetta shell works
-well.
+It has been [reported](https://github.com/fjvallarino/monomer/issues/1) that:
+
+- Building for x86 and running the application in the Rosetta shell works well.
+- Applying some workarounds, mentioned in the same issue, the build can work on
+  M1.
 
 ### Linux
 
@@ -152,8 +155,9 @@ stack run generative
 
 ## Development mode
 
-Since compilation times can be annoying, I personally prefer to rely on `ghcid`
-for a nicer development experience. First, you need to install it:
+Since compilation times can be annoying, I personally prefer to rely on
+[ghcid](https://github.com/ndmitchell/ghcid) for a nicer development experience.
+First, you need to install it:
 
 ```bash
 stack install ghcid
@@ -165,11 +169,8 @@ Then, inside your project's directory:
 ghcid
 ```
 
-If you use Visual Studio Code, you can also use this very nice extension:
-
-```
-https://marketplace.visualstudio.com/items?itemName=ndmitchell.haskell-ghcid
-```
+If you use Visual Studio Code, you can also use this [very nice
+extension](https://marketplace.visualstudio.com/items?itemName=ndmitchell.haskell-ghcid).
 
 Once installed, pressing `Ctrl-Shift-P` will allow you to invoke the
 `Start Ghcid` command. You can also run `ghcid` on the command line directly.
@@ -177,6 +178,9 @@ Once installed, pressing `Ctrl-Shift-P` will allow you to invoke the
 With this you will be running your application in interpreted mode (`ghcid`
 under the hood uses `ghci`), allowing you to make changes and test them almost
 immediately.
+
+Note: when a file is saved, a new instance of the application will be in a new
+window. The previous window needs to be closed manually.
 
 ## Notes for macOS users
 

--- a/docs/tutorials/01-basics.md
+++ b/docs/tutorials/01-basics.md
@@ -3,7 +3,7 @@
 A Monomer application has five main components that are provided to the
 `startApp` function:
 
-- **Model**: contains the information your application uses.
+- **Model**: contains data specific to your application.
 - **Events**: generated from user actions or asynchronous tasks.
 - **Build UI function**: creates the UI using the current model.
 - **Event handler**: reacts to events and can update the model, run asynchronous
@@ -115,7 +115,7 @@ Before moving forward, a quick clarification:
   its location, size, visibility, children, etc. When mentioning the _"widget
   tree"_, it really is the _"widget node tree"_. All the functions used
   throughout the tutorials to create `widgets` return `WidgetNode`s, to allow
-  composing them into larger structures..
+  composing them into larger structures.
 
 We'll explore some basic widgets next.
 

--- a/docs/tutorials/02-styling.md
+++ b/docs/tutorials/02-styling.md
@@ -24,10 +24,22 @@ label or widget that displays text.
 label text `styleBasic` [textFont "Medium", textSize 20]
 ```
 
-There are several functions you can use to alter widget node. These functions
-are generally used infix, since the intention is clearer that way. In
-particular, the `styleBasic` function allows providing different style options
-with a list.
+A widget node can be assigned different styles depending on its current status.
+These styles can be set using the `style...` family of functions, and they
+receive a list of options. These functions are generally used infix. They are:
+
+- `styleBasic`: Default style of a widget. It serves as the base for all the
+  other styles states when a value is not overriden.
+- `styleFocus`: Used when the widget has keyboard focus. In general a border is
+  displayed.
+- `styleHover`: Used when the widget is hovered. In general an alternative
+  background color is used.
+- `styleFocusHover`: Used when the node is both focused and hovered. Used to
+  have better control in cases when the mix of focus and hover styles do not
+  match expectations.
+- `styleActive`: Used when a mouse press was started in the widget and the
+  pointer is inside its boundaries.
+- `styleDisabled`: Used when the `nodeEnabled` attribute has been set to False.
 
 Since this style is used a few times in the example, it would be nice to avoid
 duplicating the code all over the example. An easy way to avoid this is to
@@ -37,14 +49,30 @@ create a function that returns the label styled as needed:
 titleText text = label text `styleBasic` [textFont "Medium", textSize 20]
 ```
 
+If you apply `styleBasic` to the result of `titleText`, the options will be
+combined. This means that:
+
+```haskell
+newNode = titleText "Title" `styleBasic` [textSize 40, textColor red]
+```
+
+will have:
+
+```haskell
+[textFont "Medium", textSize 40, textColor red]
+```
+
+If you want to replace the style state in a node, you can use `styleBasicSet`.
+All the `style...` functions have an associated `style...Set` version.
+
 In general, all components which display text support the following styles:
 
-- textFont
-- textSize
-- textColor
-- textUnderline/textOverline/textThroughline
-- textCenter/textLeft/textRight
-- textMiddle/textTop/textBottom
+- `textFont`
+- `textSize`
+- `textColor`
+- `textUnderline`/`textOverline`/`textThroughline`
+- `textCenter`/`textLeft`/`textRight`
+- `textMiddle`/`textTop`/`textBottom`
 
 All dimensions in Monomer are expressed in pixels.
 

--- a/docs/tutorials/02-styling.md
+++ b/docs/tutorials/02-styling.md
@@ -26,17 +26,20 @@ label text `styleBasic` [textFont "Medium", textSize 20]
 
 A widget node can be assigned different styles depending on its current status.
 These styles can be set using the `style...` family of functions, and they
-receive a list of options. These functions are generally used infix. They are:
+receive a list of attributes. These functions are generally used infix. They
+are:
 
 - `styleBasic`: Default style of a widget. It serves as the base for all the
-  other styles states when a value is not overriden.
+  other style states when an attribute is not overriden.
+- `styleHover`: Used when the widget is hovered with a pointing device. In
+  general an alternative background color is used.
 - `styleFocus`: Used when the widget has keyboard focus. In general a border is
   displayed.
-- `styleHover`: Used when the widget is hovered. In general an alternative
-  background color is used.
-- `styleFocusHover`: Used when the node is both focused and hovered. Used to
-  have better control in cases when the mix of focus and hover styles do not
-  match expectations.
+- `styleFocusHover`: Used when the widget is both focused and hovered. In this
+  situation the attributes defined in focus and hover will be combined, with
+  focus attributes taking precedence. This style state allows for better control
+  in cases when the combination of focus and hover styles do not match
+  expectations.
 - `styleActive`: Used when a mouse press was started in the widget and the
   pointer is inside its boundaries.
 - `styleDisabled`: Used when the `nodeEnabled` attribute has been set to False.
@@ -49,14 +52,14 @@ create a function that returns the label styled as needed:
 titleText text = label text `styleBasic` [textFont "Medium", textSize 20]
 ```
 
-If you apply `styleBasic` to the result of `titleText`, the options will be
+If you apply `styleBasic` to the result of `titleText`, the attributes will be
 combined. This means that:
 
 ```haskell
 newNode = titleText "Title" `styleBasic` [textSize 40, textColor red]
 ```
 
-will have:
+will result in:
 
 ```haskell
 [textFont "Medium", textSize 40, textColor red]

--- a/docs/tutorials/03-life-cycle.md
+++ b/docs/tutorials/03-life-cycle.md
@@ -12,10 +12,11 @@ When the application starts, the view is created from scratch by calling buildUI
 and providing the initial model given to startApp. During this process, each
 widget has its init function called.
 
-From that point on, whenever the model changes, buildUI will be called with the
-current model but its result will not be used directly. The reason for that is
-widgets may have internal state that needs to be kept around. To take care of
-this, the merge process is used.
+From that point on, whenever the model changes buildUI will be called with the
+current model, although the new version of the view will not be used directly.
+The reason is widgets in the old view may have internal state that needs to be
+kept around to be used by their new versions. The merge process takes care of
+this.
 
 ## Merge process
 

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -445,6 +445,7 @@ test-suite monomer-test
   other-modules:
       Monomer.Common.CursorIconSpec
       Monomer.Core.SizeReqSpec
+      Monomer.Core.StyleUtilSpec
       Monomer.Graphics.UtilSpec
       Monomer.TestEventUtil
       Monomer.TestUtil

--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -541,35 +541,64 @@ class CmbResizeFactorDim t where
 
 -- Style
 infixl 5 `styleBasic`
+infixl 5 `styleBasicSet`
+
 infixl 5 `styleHover`
+infixl 5 `styleHoverSet`
+
 infixl 5 `styleFocus`
+infixl 5 `styleFocusSet`
+
 infixl 5 `styleFocusHover`
+infixl 5 `styleFocusHoverSet`
+
 infixl 5 `styleActive`
+infixl 5 `styleActiveSet`
+
 infixl 5 `styleDisabled`
+infixl 5 `styleDisabledSet`
 
--- | Basic style combinator, used mainly infix for widgets as a list.
+-- | Basic style combinator, mainly used infix with widgets.
 class CmbStyleBasic t where
+  -- | Merges the new basic style states with the existing ones.
   styleBasic :: t -> [StyleState] -> t
+  -- | Sets the new basic style states overriding the existing ones.
+  styleBasicSet :: t -> [StyleState] -> t
 
--- | Hover style combinator, used mainly infix for widgets as a list.
+-- | Hover style combinator, mainly used infix with widgets.
 class CmbStyleHover t where
+  -- | Merges the new hover style states with the existing ones.
   styleHover :: t -> [StyleState] -> t
+  -- | Sets the new hover style states overriding the existing ones.
+  styleHoverSet :: t -> [StyleState] -> t
 
--- | Focus style combinator, used mainly infix for widgets as a list.
+-- | Focus style combinator, mainly used infix with widgets.
 class CmbStyleFocus t where
+  -- | Merges the new focus style states with the existing ones.
   styleFocus :: t -> [StyleState] -> t
+  -- | Sets the new focus style states overriding the existing ones.
+  styleFocusSet :: t -> [StyleState] -> t
 
--- | Focus Hover style combinator, used mainly infix for widgets as a list.
+-- | Focus Hover style combinator, mainly used infix with widgets.
 class CmbStyleFocusHover t where
+  -- | Merges the new focus hover style states with the existing ones.
   styleFocusHover :: t -> [StyleState] -> t
+  -- | Sets the new focus hover style states overriding the existing ones.
+  styleFocusHoverSet :: t -> [StyleState] -> t
 
--- | Active style combinator, used mainly infix for widgets as a list.
+-- | Active style combinator, mainly used infix with widgets.
 class CmbStyleActive t where
+  -- | Merges the new active style states with the existing ones.
   styleActive :: t -> [StyleState] -> t
+  -- | Sets the new active style states overriding the existing ones.
+  styleActiveSet :: t -> [StyleState] -> t
 
--- | Disabled style combinator, used mainly infix for widgets as a list.
+-- | Disabled style combinator, mainly used infix with widgets.
 class CmbStyleDisabled t where
+  -- | Merges the new disabled style states with the existing ones.
   styleDisabled :: t -> [StyleState] -> t
+  -- | Sets the new disabled style states overriding the existing ones.
+  styleDisabledSet :: t -> [StyleState] -> t
 
 -- | Ignore theme settings and start with blank style.
 class CmbIgnoreTheme t where

--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -558,42 +558,71 @@ infixl 5 `styleActiveSet`
 infixl 5 `styleDisabled`
 infixl 5 `styleDisabledSet`
 
--- | Basic style combinator, mainly used infix with widgets.
+{-|
+Basic style combinator, mainly used infix with widgets.
+
+Represents the default style of a widget. It serves as the base for all the
+other style states when an attribute is not overriden.
+-}
 class CmbStyleBasic t where
   -- | Merges the new basic style states with the existing ones.
   styleBasic :: t -> [StyleState] -> t
   -- | Sets the new basic style states overriding the existing ones.
   styleBasicSet :: t -> [StyleState] -> t
 
--- | Hover style combinator, mainly used infix with widgets.
+{-|
+Hover style combinator, mainly used infix with widgets.
+
+Used when the widget is hovered with a pointing device.
+-}
 class CmbStyleHover t where
   -- | Merges the new hover style states with the existing ones.
   styleHover :: t -> [StyleState] -> t
   -- | Sets the new hover style states overriding the existing ones.
   styleHoverSet :: t -> [StyleState] -> t
 
--- | Focus style combinator, mainly used infix with widgets.
+{-|
+Focus style combinator, mainly used infix with widgets.
+
+Used when the widget has keyboard focus.
+-}
 class CmbStyleFocus t where
   -- | Merges the new focus style states with the existing ones.
   styleFocus :: t -> [StyleState] -> t
   -- | Sets the new focus style states overriding the existing ones.
   styleFocusSet :: t -> [StyleState] -> t
 
--- | Focus Hover style combinator, mainly used infix with widgets.
+{-|
+Focus Hover style combinator, mainly used infix with widgets.
+
+Used when the widget is both focused and hovered. In this situation the
+attributes defined in focus and hover will be combined, with focus attributes
+taking precedence. This style state allows for better control in cases when the
+combination of focus and hover styles do not match expectations.
+-}
 class CmbStyleFocusHover t where
   -- | Merges the new focus hover style states with the existing ones.
   styleFocusHover :: t -> [StyleState] -> t
   -- | Sets the new focus hover style states overriding the existing ones.
   styleFocusHoverSet :: t -> [StyleState] -> t
 
--- | Active style combinator, mainly used infix with widgets.
+{-|
+Active style combinator, mainly used infix with widgets.
+
+Used when a mouse press was started in the widget and the pointer is inside its
+boundaries.
+-}
 class CmbStyleActive t where
   -- | Merges the new active style states with the existing ones.
   styleActive :: t -> [StyleState] -> t
   -- | Sets the new active style states overriding the existing ones.
   styleActiveSet :: t -> [StyleState] -> t
 
--- | Disabled style combinator, mainly used infix with widgets.
+{-|
+Disabled style combinator, mainly used infix with widgets.
+
+Used when the 'nodeEnabled' attribute has been set to False.
+-}
 class CmbStyleDisabled t where
   -- | Merges the new disabled style states with the existing ones.
   styleDisabled :: t -> [StyleState] -> t

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -222,7 +222,7 @@ mainLoop
 mainLoop window fontManager config loopArgs = do
   let MainLoopArgs{..} = loopArgs
 
-  startTs <- getEllapsedTimestamp _mlAppStartTs
+  startTs <- getEllapsedTimestampSince _mlAppStartTs
   events <- SDL.pumpEvents >> SDL.pollEvents
 
   windowSize <- use L.windowSize
@@ -309,7 +309,7 @@ mainLoop window fontManager config loopArgs = do
       handleResizeWidgets (seWenv, seRoot, Seq.empty)
     else return (seWenv, seRoot, Seq.empty)
 
-  endTs <- getEllapsedTimestamp _mlAppStartTs
+  endTs <- getEllapsedTimestampSince _mlAppStartTs
 
   -- Rendering
   renderCurrentReq <- checkRenderCurrent startTs _mlLatestRenderTs
@@ -512,7 +512,7 @@ getCurrentTimestamp = toMs <$> liftIO getCurrentTime
   where
     toMs = floor . (1e3 *) . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
 
-getEllapsedTimestamp :: MonadIO m => Timestamp -> m Timestamp
-getEllapsedTimestamp start = do
+getEllapsedTimestampSince :: MonadIO m => Timestamp -> m Timestamp
+getEllapsedTimestampSince start = do
   ts <- getCurrentTimestamp
   return (ts - start)

--- a/test/unit/Monomer/Core/StyleUtilSpec.hs
+++ b/test/unit/Monomer/Core/StyleUtilSpec.hs
@@ -1,0 +1,78 @@
+{-|
+Module      : Monomer.Core.StyleUtilSpec
+Copyright   : (c) 2018 Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for StyleUtil functions.
+-}
+module Monomer.Core.StyleUtilSpec (spec) where
+
+import Control.Lens
+import Test.Hspec
+
+import Monomer.Core.Combinators
+import Monomer.Graphics (Color, rgb)
+import Monomer.Widgets.Singles.Spacer
+
+import qualified Monomer.Lens as L
+
+red :: Color
+red = rgb 255 0 0
+
+spec :: Spec
+spec = describe "StyleUtil" $ do
+  styleStateSpec
+
+styleStateSpec :: Spec
+styleStateSpec = describe "StyleState actions" $ do
+  describe "StyleState merge" $ do
+    it "should merge basic styles" $ do
+      checkStyleAction styleBasic L.basic mergedStyles
+
+    it "should merge hover styles" $ do
+      checkStyleAction styleHover L.hover mergedStyles
+
+    it "should merge focus styles" $ do
+      checkStyleAction styleFocus L.focus mergedStyles
+
+    it "should merge hover focus styles" $ do
+      checkStyleAction styleFocusHover L.focusHover mergedStyles
+
+    it "should merge active styles" $ do
+      checkStyleAction styleActive L.active mergedStyles
+
+    it "should merge disabled styles" $ do
+      checkStyleAction styleDisabled L.disabled mergedStyles
+
+  describe "StyleState merge" $ do
+    it "should set basic styles" $ do
+      checkStyleAction styleBasicSet L.basic newStyles
+
+    it "should set hover styles" $ do
+      checkStyleAction styleHoverSet L.hover newStyles
+
+    it "should set focus styles" $ do
+      checkStyleAction styleFocusSet L.focus newStyles
+
+    it "should set focus hover styles" $ do
+      checkStyleAction styleFocusHoverSet L.focusHover newStyles
+
+    it "should set active styles" $ do
+      checkStyleAction styleActiveSet L.active newStyles
+
+    it "should set disabled styles" $ do
+      checkStyleAction styleDisabledSet L.disabled newStyles
+
+  where
+    baseStyles = [width 200, padding 10]
+    newStyles = [padding 5, bgColor red]
+    mergedStyles = [width 200, padding 5, bgColor red]
+
+    checkStyleAction styleFn field targetStyles = do
+      let node = styleFn spacer baseStyles
+      let newNode = styleFn node newStyles
+
+      newNode ^. L.info . L.style . field `shouldBe` Just (mconcat targetStyles)

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -8,7 +8,10 @@ import qualified SDL.Raw as Raw
 import Monomer.TestUtil (useVideoSubSystem)
 
 import qualified Monomer.Common.CursorIconSpec as CursorIconSpec
+
 import qualified Monomer.Core.SizeReqSpec as SizeReqSpec
+import qualified Monomer.Core.StyleUtilSpec as StyleUtilSpec
+
 import qualified Monomer.Graphics.UtilSpec as GraphicsUtilSpec
 
 import qualified Monomer.Widgets.CompositeSpec as CompositeSpec
@@ -88,6 +91,7 @@ common = describe "Common" $ do
 core :: Spec
 core = describe "Core" $ do
   SizeReqSpec.spec
+  StyleUtilSpec.spec
 
 graphics :: Spec
 graphics = describe "Graphics" $ do


### PR DESCRIPTION
Changes the behavior of `styleBasic` and related functions to combine style options instead of replacing them; this behavior is more intuitive.

The previous behavior is still available with `styleBasicSet` and related.
