### PR TITLE
Fix differences in glyphs positions used by FontManager and nanovg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Properly handle `SetFocusOnKey` for `textArea` ([#80](https://github.com/fjvallarino/monomer/issues/80)).
 - Lens tutorial sample code ([PR #95](https://github.com/fjvallarino/monomer/pull/95) and [PR #98](https://github.com/fjvallarino/monomer/pull/98)). Thanks @Clindbergh!
 - ColorPicker's numericFields vertical alignment ([PR #108](https://github.com/fjvallarino/monomer/pull/108)).
+- Differences in glyphs positions used by FontManager and nanovg ([PR #105](https://github.com/fjvallarino/monomer/pull/105)).
 
 ### Added
 
@@ -25,8 +26,8 @@
   in `handleEvent` to know when the model changed. Widgets that want to report model changes to its parent can
   use `Report`/`RequestParent`; an example can be found in `ColorPicker` ([PR #71](https://github.com/fjvallarino/monomer/pull/71)).
 - The `keystroke` widget now supports the `Backspace` key ([PR #74](https://github.com/fjvallarino/monomer/pull/74)).
-- `Timestamp` is now a newtype. Enforce use of this type instead of `Int` when appropriate ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 - `style...` family of functions now combine new attributes with the existing ones ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
+- `Timestamp` is now a newtype. Enforce use of this type instead of `Int` when appropriate ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 - `Timestamp` was renamed to `Millisecond`. The rationale is that since both timestamps and durations are used frequently in calculations (and in the context of Monomer timestamps and durations indeed represent time in milliseconds), having separate types for Timestamp and Duration caused more harm than good ([PR #107](https://github.com/fjvallarino/monomer/pull/107)).
 
 ### Renamed

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -42,7 +42,7 @@ makeFontManager fonts dpr = do
 
   This should be reviewed/improved.
   -}
-  let adjustedDpr = min (dpr * 4) 4
+  let adjustedDpr = 4
 
   ctx <- fmInit adjustedDpr
 

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -35,7 +35,7 @@ makeFontManager
   -> Double       -- ^ The device pixel rate.
   -> IO FontManager  -- ^ The created renderer.
 makeFontManager fonts dpr = do
-  ctx <- fmInit 1 --dpr
+  ctx <- fmInit dpr
 
   validFonts <- foldM (loadFont ctx) [] fonts
 

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -35,14 +35,23 @@ makeFontManager
   -> Double       -- ^ The device pixel rate.
   -> IO FontManager  -- ^ The created renderer.
 makeFontManager fonts dpr = do
-  ctx <- fmInit dpr
+  {-
+  Awful fix/workaround to account for rounding errors/differences in how scaling
+  is performed. The nvg__getFontScale function calculates a scale based on
+  internal state and seems to be the source of the differences.
+
+  This should be reviewed/improved.
+  -}
+  let adjustedDpr = min (dpr * 4) 4
+
+  ctx <- fmInit adjustedDpr
 
   validFonts <- foldM (loadFont ctx) [] fonts
 
   when (null validFonts) $
     putStrLn "Could not find any valid fonts. Text size calculations will fail."
-  
-  return $ newManager ctx dpr
+
+  return $ newManager ctx adjustedDpr
 
 newManager :: FMContext -> Double -> FontManager
 newManager ctx dpr = FontManager {..} where

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -113,6 +113,10 @@ makeRenderer fonts dpr = do
 
 newRenderer :: VG.Context -> Double -> IORef Env -> Renderer
 newRenderer c rdpr envRef = Renderer {..} where
+  {-
+  rdpr is used to let nanovg know the real device pixel rate.
+  dpr is set to 1 to disable all NanoVGRenderer internal calculations.
+  -}
   dpr = 1
 
   beginFrame w h = do


### PR DESCRIPTION
Adjust dpr in FontManager to approximate formula used by nvg__getFontScale.

Discussed here: https://github.com/fjvallarino/monomer/issues/101