### PR TITLE
Standardize names and arguments for Composite's mergeReqs and mergeModel

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@
 - New field `_weAppStartTs` in `WidgetEnv`, complementary to `_weTimestamp`, representing the time in milliseconds when the application started. Added utility function `currentTimeMs` that returns their sum with a polymorphic type ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 - `style...Set` family of functions ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
 - Several sizeReq helpers ([PR #106](https://github.com/fjvallarino/monomer/pull/106)).
+- `compositeMergeEvents`, for completeness ([PR #114](https://github.com/fjvallarino/monomer/pull/114)).
 
 ### Changed
 
@@ -30,6 +31,8 @@
 - `style...` family of functions now combine new attributes with the existing ones ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
 - `Timestamp` is now a newtype. Enforce use of this type instead of `Int` when appropriate ([PR #103](https://github.com/fjvallarino/monomer/pull/103)).
 - `Timestamp` was renamed to `Millisecond`. The rationale is that since both timestamps and durations are used frequently in calculations (and in the context of Monomer timestamps and durations indeed represent time in milliseconds), having separate types for Timestamp and Duration caused more harm than good ([PR #107](https://github.com/fjvallarino/monomer/pull/107)).
+- `compositeMergeModel` (previously `customModelBuilder`) now receives `WidgetEnv` as its first parameter ([PR #114](https://github.com/fjvallarino/monomer/pull/114)).
+- `compositeMergeReqs` now receives `parentModel` and `oldModel` too ([PR #114](https://github.com/fjvallarino/monomer/pull/114)).
 
 ### Renamed
 
@@ -37,6 +40,9 @@
   - `findWidgetByPath` -> `findChildNodeInfoByPath`.
   - `findWidgetBranchByPath` -> `findChildBranchByPath`.
   - `findWidgetIdFromPath` -> `widgetIdFromPath`.
+- Composite merge related ([PR #114](https://github.com/fjvallarino/monomer/pull/114))
+  - `customModelBuilder` -> `compositeMergeModel`
+  - `CompositeCustomModelBuilder` -> `MergeModelHandler`.
 
 ### Removed
 

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -13,6 +13,8 @@ Helper functions creating, validating and merging size requirements.
 module Monomer.Core.SizeReq (
   SizeReqUpdater(..),
   clearExtra,
+  clearExtraW,
+  clearExtraH,
   fixedToMinW,
   fixedToMinH,
   fixedToMaxW,

--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -42,6 +42,7 @@ module Monomer.Widgets.Composite (
   CompositeEvent,
   MergeRequired,
   MergeReqsHandler,
+  MergeEventsHandler,
   MergeModelHandler,
   EventHandler,
   UIBuilder,
@@ -49,6 +50,7 @@ module Monomer.Widgets.Composite (
   ProducerHandler,
   CompMsgUpdate,
   compositeMergeReqs,
+  compositeMergeEvents,
   compositeMergeModel,
 
   -- * Constructors
@@ -107,6 +109,16 @@ type MergeReqsHandler s e sp
   -> s                    -- ^ Old composite model.
   -> s                    -- ^ New composite model.
   -> [WidgetRequest s e]  -- ^ The list of requests.
+
+-- | Generates events during the merge process.
+type MergeEventsHandler s e sp
+  = WidgetEnv s e         -- ^ Widget environment.
+  -> WidgetNode s e       -- ^ New widget node.
+  -> WidgetNode s e       -- ^ Old widget node.
+  -> sp                   -- ^ Parent model.
+  -> s                    -- ^ Old composite model.
+  -> s                    -- ^ New composite model.
+  -> [e]                  -- ^ The list of events.
 
 -- | Allows updating the composite model with information from the parent model.
 type MergeModelHandler s e sp
@@ -320,6 +332,16 @@ compositeMergeReqs :: MergeReqsHandler s e sp -> CompositeCfg s e sp ep
 compositeMergeReqs fn = def {
   _cmcMergeReqs = [fn]
 }
+
+-- | Generate events during the merge process.
+compositeMergeEvents
+  :: WidgetEvent e => MergeEventsHandler s e sp -> CompositeCfg s e sp ep
+compositeMergeEvents fn = cfg where
+  cfg = def {
+    _cmcMergeReqs = [wrapper]
+  }
+  wrapper wenv node oldNode parentModel oldModel newModel
+    = RaiseEvent <$> fn wenv node oldNode parentModel oldModel newModel
 
 {-|
 Allows updating the composite model with information from the parent model.

--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -327,13 +327,21 @@ instance CmbOnVisibleChange (CompositeCfg s e sp ep) e where
     _cmcOnVisibleChange = [fn]
   }
 
--- | Generate WidgetRequests during the merge process.
+{-|
+Generate WidgetRequests during the merge process.
+
+This function is not called during initialization; 'onInitReq' can be used.
+-}
 compositeMergeReqs :: MergeReqsHandler s e sp -> CompositeCfg s e sp ep
 compositeMergeReqs fn = def {
   _cmcMergeReqs = [fn]
 }
 
--- | Generate events during the merge process.
+{-|
+Generate events during the merge process.
+
+This function is not called during initialization; 'onInit' can be used.
+-}
 compositeMergeEvents
   :: WidgetEvent e => MergeEventsHandler s e sp -> CompositeCfg s e sp ep
 compositeMergeEvents fn = cfg where
@@ -351,6 +359,9 @@ binding.
 For example, a database record may be binded as the model from the parent, but
 the composite needs its own boolean flags to toggle visibility on different
 sections.
+
+This function is called during both merge and init. On init, the oldModel will
+be equal to the current model.
 -}
 compositeMergeModel :: MergeModelHandler s e sp -> CompositeCfg s e sp ep
 compositeMergeModel fn = def {

--- a/src/Monomer/Widgets/Containers/Confirm.hs
+++ b/src/Monomer/Widgets/Containers/Confirm.hs
@@ -142,8 +142,8 @@ confirmMsg_ message acceptEvt cancelEvt configs = newNode where
   compCfg = [compositeMergeReqs mergeReqs]
   newNode = compositeD_ "confirm" (WidgetValue ()) createUI handleEvent compCfg
 
-mergeReqs :: MergeReqsHandler s e
-mergeReqs wenv newNode oldNode model = reqs where
+mergeReqs :: MergeReqsHandler s e sp
+mergeReqs wenv newNode oldNode parentModel oldModel model = reqs where
   acceptPath = SetFocus <$> widgetIdFromKey wenv "acceptBtn"
   isVisible node = node ^. L.info . L.visible
   reqs


### PR DESCRIPTION
These changes were made for consistency and to allow the same use cases as with regular widgets.

- Renamed:
  - `customModelBuilder` -> `compositeMergeModel`
  - `CompositeCustomModelBuilder` -> `MergeModelHandler`.
- Added
  - `compositeMergeEvents`
- Changed
  - `compositeMergeModel` (previously `customModelBuilder`) now receives `WidgetEnv` as its first parameter.
  - `compositeMergeReqs` now receives `parentModel` and `oldModel` too.

Note: `compositeMergeModel` does not receive the `node` and `oldNode` because `node` is created using the model, and `oldNode` may not exist when invoked during `onInit`.