### PR TITLE
Allow using symbols for keystroke definitions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@
 - `style...Set` family of functions ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
 - Several sizeReq helpers ([PR #106](https://github.com/fjvallarino/monomer/pull/106)).
 - `compositeMergeEvents`, for completeness ([PR #114](https://github.com/fjvallarino/monomer/pull/114)).
+- Support for symbols and other keys in `keystroke` ([PR #117](https://github.com/fjvallarino/monomer/pull/117)).
 
 ### Changed
 

--- a/examples/tutorial/Tutorial02_Styling.hs
+++ b/examples/tutorial/Tutorial02_Styling.hs
@@ -29,7 +29,6 @@ data AppModel = AppModel {
 
 data AppEvent
   = AppInit
-  | AppCombination Text
   deriving (Eq, Show)
 
 makeLenses 'AppModel
@@ -41,19 +40,7 @@ buildUI
 buildUI wenv model = widgetTree where
   widgetTree = vstack [
       titleText "Text",
-      keystroke_ [
-          ("e", AppCombination "e"),
-          ("+", AppCombination "+"),
-          ("^", AppCombination "^"),
-          ("Dash", AppCombination "-"),
-          ("ddd", AppCombination "["),
-          ("]", AppCombination "]"),
-          ("(", AppCombination "("),
-          (")", AppCombination ")"),
-          ("{", AppCombination "{"),
-          ("}", AppCombination "}")
-        ] [ignoreChildrenEvts] $
-        box (textField sampleText) `styleBasic` [paddingV 10],
+      box (textField sampleText) `styleBasic` [paddingV 10],
 
       titleText "Font name",
       hgrid [
@@ -112,10 +99,6 @@ handleEvent
   -> [AppEventResponse AppModel AppEvent]
 handleEvent wenv node model evt = case evt of
   AppInit -> []
-  AppCombination txt -> [ Task $ do
-      print txt
-      return AppInit
-    ]
 
 main02 :: IO ()
 main02 = do

--- a/examples/tutorial/Tutorial02_Styling.hs
+++ b/examples/tutorial/Tutorial02_Styling.hs
@@ -29,6 +29,7 @@ data AppModel = AppModel {
 
 data AppEvent
   = AppInit
+  | AppCombination Text
   deriving (Eq, Show)
 
 makeLenses 'AppModel
@@ -40,7 +41,19 @@ buildUI
 buildUI wenv model = widgetTree where
   widgetTree = vstack [
       titleText "Text",
-      box (textField sampleText) `styleBasic` [paddingV 10],
+      keystroke_ [
+          ("e", AppCombination "e"),
+          ("+", AppCombination "+"),
+          ("^", AppCombination "^"),
+          ("Dash", AppCombination "-"),
+          ("ddd", AppCombination "["),
+          ("]", AppCombination "]"),
+          ("(", AppCombination "("),
+          (")", AppCombination ")"),
+          ("{", AppCombination "{"),
+          ("}", AppCombination "}")
+        ] [ignoreChildrenEvts] $
+        box (textField sampleText) `styleBasic` [paddingV 10],
 
       titleText "Font name",
       hgrid [
@@ -99,6 +112,10 @@ handleEvent
   -> [AppEventResponse AppModel AppEvent]
 handleEvent wenv node model evt = case evt of
   AppInit -> []
+  AppCombination txt -> [ Task $ do
+      print txt
+      return AppInit
+    ]
 
 main02 :: IO ()
 main02 = do

--- a/src/Monomer/Event/Keyboard.hs
+++ b/src/Monomer/Event/Keyboard.hs
@@ -337,6 +337,56 @@ keyY = getKeyCode SDL.KeycodeY
 keyZ :: KeyCode
 keyZ = getKeyCode SDL.KeycodeZ
 
+-- Key pad
+keyPadDivide :: KeyCode
+keyPadDivide = getKeyCode SDL.KeycodeKPDivide
+
+keyPadMultiply :: KeyCode
+keyPadMultiply = getKeyCode SDL.KeycodeKPMultiply
+
+keyPadMinus :: KeyCode
+keyPadMinus = getKeyCode SDL.KeycodeKPMinus
+
+keyPadPlus :: KeyCode
+keyPadPlus = getKeyCode SDL.KeycodeKPPlus
+
+keyPadEnter :: KeyCode
+keyPadEnter = getKeyCode SDL.KeycodeKPEnter
+
+keyPadPeriod :: KeyCode
+keyPadPeriod = getKeyCode SDL.KeycodeKPPeriod
+
+-- Key pad numbers
+keyPad0 :: KeyCode
+keyPad0 = getKeyCode SDL.KeycodeKP0
+
+keyPad1 :: KeyCode
+keyPad1 = getKeyCode SDL.KeycodeKP1
+
+keyPad2 :: KeyCode
+keyPad2 = getKeyCode SDL.KeycodeKP2
+
+keyPad3 :: KeyCode
+keyPad3 = getKeyCode SDL.KeycodeKP3
+
+keyPad4 :: KeyCode
+keyPad4 = getKeyCode SDL.KeycodeKP4
+
+keyPad5 :: KeyCode
+keyPad5 = getKeyCode SDL.KeycodeKP5
+
+keyPad6 :: KeyCode
+keyPad6 = getKeyCode SDL.KeycodeKP6
+
+keyPad7 :: KeyCode
+keyPad7 = getKeyCode SDL.KeycodeKP7
+
+keyPad8 :: KeyCode
+keyPad8 = getKeyCode SDL.KeycodeKP8
+
+keyPad9 :: KeyCode
+keyPad9 = getKeyCode SDL.KeycodeKP9
+
 --
 
 -- Mod keys
@@ -657,3 +707,53 @@ isKeyY = (== keyY)
 
 isKeyZ :: KeyCode -> Bool
 isKeyZ = (== keyZ)
+
+-- Key pad
+isKeyPadDivide :: KeyCode -> Bool
+isKeyPadDivide = (== keyPadDivide)
+
+isKeyPadMultiply :: KeyCode -> Bool
+isKeyPadMultiply = (== keyPadMultiply)
+
+isKeyPadMinus :: KeyCode -> Bool
+isKeyPadMinus = (== keyPadMinus)
+
+isKeyPadPlus :: KeyCode -> Bool
+isKeyPadPlus = (== keyPadPlus)
+
+isKeyPadEnter :: KeyCode -> Bool
+isKeyPadEnter = (== keyPadEnter)
+
+isKeyPadPeriod :: KeyCode -> Bool
+isKeyPadPeriod = (== keyPadPeriod)
+
+-- Key pad numbers
+isKeyPad0 :: KeyCode -> Bool
+isKeyPad0 = (== keyPad0)
+
+isKeyPad1 :: KeyCode -> Bool
+isKeyPad1 = (== keyPad1)
+
+isKeyPad2 :: KeyCode -> Bool
+isKeyPad2 = (== keyPad2)
+
+isKeyPad3 :: KeyCode -> Bool
+isKeyPad3 = (== keyPad3)
+
+isKeyPad4 :: KeyCode -> Bool
+isKeyPad4 = (== keyPad4)
+
+isKeyPad5 :: KeyCode -> Bool
+isKeyPad5 = (== keyPad5)
+
+isKeyPad6 :: KeyCode -> Bool
+isKeyPad6 = (== keyPad6)
+
+isKeyPad7 :: KeyCode -> Bool
+isKeyPad7 = (== keyPad7)
+
+isKeyPad8 :: KeyCode -> Bool
+isKeyPad8 = (== keyPad8)
+
+isKeyPad9 :: KeyCode -> Bool
+isKeyPad9 = (== keyPad9)

--- a/src/Monomer/Widgets/Containers/Keystroke.hs
+++ b/src/Monomer/Widgets/Containers/Keystroke.hs
@@ -265,9 +265,9 @@ partToStroke ks "Shift" = ks & ksShift .~ True
 -- Main keys
 partToStroke ks "Backspace" = ks & ksKeys %~ Set.insert keyBackspace
 partToStroke ks "Caps" = ks & ksKeys %~ Set.insert keyCapsLock
-partToStroke ks "Dash" = ks & ksKeys %~ Set.insert keyMinus
 partToStroke ks "Delete" = ks & ksKeys %~ Set.insert keyDelete
 partToStroke ks "Enter" = ks & ksKeys %~ Set.insert keyReturn
+partToStroke ks "KpEnter" = ks & ksKeys %~ Set.insert keyPadEnter
 partToStroke ks "Esc" = ks & ksKeys %~ Set.insert keyEscape
 partToStroke ks "Return" = ks & ksKeys %~ Set.insert keyReturn
 partToStroke ks "Space" = ks & ksKeys %~ Set.insert keySpace
@@ -291,6 +291,7 @@ partToStroke ks "F10" = ks & ksKeys %~ Set.insert keyF10
 partToStroke ks "F11" = ks & ksKeys %~ Set.insert keyF11
 partToStroke ks "F12" = ks & ksKeys %~ Set.insert keyF12
 -- Other keys (numbers, letters, points, etc)
+partToStroke ks "Dash" = partToStroke ks "-"
 partToStroke ks txt
   | isTextValidCode txt = ks
       & ksKeys %~ Set.insert (KeyCode (ord txtHead))

--- a/src/Monomer/Widgets/Containers/Keystroke.hs
+++ b/src/Monomer/Widgets/Containers/Keystroke.hs
@@ -17,9 +17,10 @@ ordered sequences (pressing "a", releasing, then "b" and "c"). The available
 keys are:
 
 - Mod keys: A, Alt, C, Ctrl, Cmd, O, Option, S, Shift
-- Action keys: Caps, Delete, Enter, Esc, Return, Space, Tab, Dash
+- Action keys: Caps, Delete, Enter, Esc, Return, Space, Tab
 - Arrows: Up, Down, Left, Right
 - Function keys: F1-F12
+- Separator: Dash (since '-' is used for defining keystrokes)
 - Symbols: brackets, ^, *, &, etc.
 - Lowercase letters (uppercase keys are reserved for mod and action keys)
 - Numbers
@@ -39,8 +40,11 @@ Note 3: Symbols that require pressing the Shift key (^, &, etc) are virtual keys
 and share the KeyCode with the symbol associated to the same physical key. This
 causes issues when detecting their pressed status, and thus it's not possible to
 combine these symbols with letters, numbers or other symbols in the same
-keystroke. It is still possible to combine them with mod keys, so using "C-^" or
-"C-[" is possible.
+keystroke. The same happens with characters that require pressing a combination
+of keys (e.g. accented characters). It is still possible to combine them with
+mod keys, so using "C-^" or "C-[" should work. If you find that binding a
+symbol/complex character does not work, try using the names of the physical keys
+instead (e.g. "Shift-e" instead of "E").
 -}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/test/unit/Monomer/Widgets/Containers/KeystrokeSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/KeystrokeSpec.hs
@@ -39,9 +39,11 @@ data TestEvt
   | TextFieldChanged Text
   | CtrlA
   | CtrlSpace
+  | CtrlDash
   | CtrlShiftSpace
   | MultiKey Int
   | FunctionKey Int
+  | SymbolKey Text
   deriving (Eq, Show)
 
 newtype TestModel = TestModel {
@@ -63,6 +65,9 @@ handleEvent = describe "handleEvent" $ do
   it "should generate an event when Ctrl-Space is pressed" $ do
     events [evtKC keySpace] `shouldBe` Seq.fromList [CtrlSpace]
 
+  it "should generate an event when Ctrl-Dash is pressed" $ do
+    events [evtKC keyMinus] `shouldBe` Seq.fromList [CtrlDash]
+
   it "should generate an event when Ctrl-Shift-Space is pressed" $ do
     events [evtKCS keySpace] `shouldBe` Seq.fromList [CtrlShiftSpace]
 
@@ -71,6 +76,14 @@ handleEvent = describe "handleEvent" $ do
     events [evtKC keyF3] `shouldBe` Seq.fromList [FunctionKey 3]
     events [evtKG keyF7] `shouldBe` Seq.fromList [FunctionKey 7]
     events [evtKS keyF12] `shouldBe` Seq.fromList [FunctionKey 12]
+
+  it "should generate events when symbol keys are pressed" $ do
+    let wenv = mockWenv (TestModel "")
+          & L.inputStatus . L.keyMod . L.leftCtrl .~ True
+    let events es = nodeHandleEventEvts wenv es kstNode
+
+    events [evtT "["] `shouldBe` Seq.fromList [SymbolKey "["]
+    events [evtT "^"] `shouldBe` Seq.fromList [SymbolKey "^"]
 
   it "should only generate events when the exact keys are pressed" $ do
     events [evtKC keyA, evtKC keyB] `shouldBe` Seq.fromList []
@@ -104,13 +117,16 @@ handleEvent = describe "handleEvent" $ do
     wenv = mockWenv (TestModel "")
     bindings = [
         ("C-Space", CtrlSpace),
+        ("C-Dash", CtrlDash),
         ("C-S-Space", CtrlShiftSpace),
         ("C-a-b-c", MultiKey 1),
         ("C-d-e", MultiKey 2),
         ("F1", FunctionKey 1),
         ("Ctrl-F3", FunctionKey 3),
         ("Cmd-F7", FunctionKey 7),
-        ("S-F12", FunctionKey 12)
+        ("S-F12", FunctionKey 12),
+        ("C-[", SymbolKey "["),
+        ("Shift-^", SymbolKey "^")
       ]
     kstNode = keystroke bindings (textField textValue)
     events es = nodeHandleEventEvts wenv es kstNode

--- a/test/unit/Monomer/Widgets/Containers/KeystrokeSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/KeystrokeSpec.hs
@@ -66,7 +66,11 @@ handleEvent = describe "handleEvent" $ do
     events [evtKC keySpace] `shouldBe` Seq.fromList [CtrlSpace]
 
   it "should generate an event when Ctrl-Dash is pressed" $ do
-    events [evtKC keyMinus] `shouldBe` Seq.fromList [CtrlDash]
+    let wenv = mockWenv (TestModel "")
+          & L.inputStatus . L.keyMod . L.leftCtrl .~ True
+    let events es = nodeHandleEventEvts wenv es kstNode
+
+    events [evtT "-"] `shouldBe` Seq.fromList [CtrlDash]
 
   it "should generate an event when Ctrl-Shift-Space is pressed" $ do
     events [evtKCS keySpace] `shouldBe` Seq.fromList [CtrlShiftSpace]


### PR DESCRIPTION
Allows using symbols for `keystroke` definitions
Adds _Dash_ as a possible input, to disambiguate from the required '-' separator.
Logs when an invalid combination is provided.

Discussed here: https://github.com/fjvallarino/monomer/issues/116
