### PR TITLE
Fix text scaling and positioning problems in FontManager

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,8 +19,9 @@
 - Properly handle `SetFocusOnKey` for `textArea` ([#80](https://github.com/fjvallarino/monomer/issues/80)).
 - Lens tutorial sample code ([PR #95](https://github.com/fjvallarino/monomer/pull/95) and [PR #98](https://github.com/fjvallarino/monomer/pull/98)). Thanks @Clindbergh!
 - ColorPicker's numericFields vertical alignment ([PR #108](https://github.com/fjvallarino/monomer/pull/108)).
-- Differences in glyphs positions used by FontManager and nanovg ([PR #105](https://github.com/fjvallarino/monomer/pull/105)).
-- `nodeInfoFromKey` relies on `nodeInfoFromPath` to retrieve information instead of fetching it directly from `WidgetEnv`'s `widgetKeyMap`, which can be stale ([PR #110](https://github.com/fjvallarino/monomer/pull/110))
+- Differences in glyphs positions used by `FontManager` and nanovg; temporary workaround ([PR #105](https://github.com/fjvallarino/monomer/pull/105)).
+- `nodeInfoFromKey` relies on `nodeInfoFromPath` to retrieve information instead of fetching it directly from `WidgetEnv`'s `widgetKeyMap`, which can be stale ([PR #110](https://github.com/fjvallarino/monomer/pull/110)).
+- Glyph positioning issues in `FontManager`; removed workaround added in #105 ([PR #125](https://github.com/fjvallarino/monomer/pull/125)).
 
 ### Added
 

--- a/cbits/fontmanager.c
+++ b/cbits/fontmanager.c
@@ -37,6 +37,7 @@ FMcontext* fmInit(float dpr)
 	// Initialize font manager context
 	ctx->fs = fonsCreateInternal(&fontParams);
 	ctx->dpr = dpr;
+	ctx->scale = 1;
 	ctx->fontSize = 16.0f;
 	ctx->letterSpacing = 0.0f;
 	ctx->lineHeight = 1.0f;
@@ -50,6 +51,10 @@ FMcontext* fmInit(float dpr)
 int fmCreateFont(FMcontext* ctx, const char* name, const char* filename)
 {
 	return fonsAddFont(ctx->fs, name, filename, 0);
+}
+
+void fmSetScale(FMcontext* ctx, float scale) {
+	ctx->scale = scale;
 }
 
 void fmFontFace(FMcontext* ctx, const char* font)
@@ -79,7 +84,7 @@ void fmTextLineHeight(FMcontext* ctx, float lineHeight)
 
 void fmTextMetrics(FMcontext* ctx, float* ascender, float* descender, float* lineh)
 {
-	float scale = ctx->dpr;
+	float scale = ctx->dpr * ctx->scale;
 	float invscale = 1.0f / scale;
 
 	if (ctx->fontId == FONS_INVALID) return;
@@ -101,7 +106,7 @@ void fmTextMetrics(FMcontext* ctx, float* ascender, float* descender, float* lin
 
 float fmTextBounds(FMcontext* ctx, float x, float y, const char* string, const char* end, float* bounds)
 {
-	float scale = ctx->dpr;
+	float scale = ctx->dpr * ctx->scale;
 	float invscale = 1.0f / scale;
 	float width;
 
@@ -127,7 +132,7 @@ float fmTextBounds(FMcontext* ctx, float x, float y, const char* string, const c
 
 int fmTextGlyphPositions(FMcontext* ctx, float x, float y, const char* string, const char* end, FMGglyphPosition* positions, int maxPositions)
 {
-	float scale = ctx->dpr;
+	float scale = ctx->dpr * ctx->scale;
 	float invscale = 1.0f / scale;
 	FONStextIter iter, prevIter;
 	FONSquad q;

--- a/cbits/fontmanager.h
+++ b/cbits/fontmanager.h
@@ -15,6 +15,7 @@
 struct FMcontext {
 	struct FONScontext* fs;
 	float dpr;
+	float scale;
 	float fontSize;
 	float letterSpacing;
 	float lineHeight;
@@ -37,6 +38,8 @@ typedef struct FMGglyphPosition FMGglyphPosition;
 FMcontext* fmInit(float dpr);
 
 int fmCreateFont(FMcontext* ctx, const char* name, const char* filename);
+
+void fmSetScale(FMcontext* ctx, float scale);
 
 void fmFontFace(FMcontext* ctx, const char* font);
 

--- a/src/Monomer/Graphics/FFI.chs
+++ b/src/Monomer/Graphics/FFI.chs
@@ -122,6 +122,8 @@ deriving instance Storable FMContext
 
 {# fun unsafe fmCreateFont {`FMContext', withCString*`Text', withCString*`Text'} -> `Int' #}
 
+{# fun unsafe fmSetScale {`FMContext', `Double'} -> `()' #}
+
 {# fun unsafe fmFontFace {`FMContext', withCString*`Text'} -> `()' #}
 
 {# fun unsafe fmFontSize {`FMContext', `Double'} -> `()' #}

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -31,8 +31,8 @@ import Monomer.Graphics.Types
 
 -- | Creates a font manager instance.
 makeFontManager
-  :: [FontDef]    -- ^ The font definitions.
-  -> Double       -- ^ The device pixel rate.
+  :: [FontDef]       -- ^ The font definitions.
+  -> Double          -- ^ The device pixel rate.
   -> IO FontManager  -- ^ The created renderer.
 makeFontManager fonts dpr = do
   ctx <- fmInit dpr
@@ -90,6 +90,7 @@ newManager ctx = FontManager {..} where
     where
       toGlyphPos chr glyph = GlyphPos {
         _glpGlyph = chr,
+        _glpX = realToFrac (glyphX glyph),
         _glpXMin = realToFrac (glyphPosMinX glyph),
         _glpXMax = realToFrac (glyphPosMaxX glyph),
         _glpYMin = realToFrac (glyphPosMinY glyph),

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -35,28 +35,22 @@ makeFontManager
   -> Double       -- ^ The device pixel rate.
   -> IO FontManager  -- ^ The created renderer.
 makeFontManager fonts dpr = do
-  {-
-  Awful fix/workaround to account for rounding errors/differences in how scaling
-  is performed. The nvg__getFontScale function calculates a scale based on
-  internal state and seems to be the source of the differences.
-
-  This should be reviewed/improved.
-  -}
-  let adjustedDpr = 4
-
-  ctx <- fmInit adjustedDpr
+  ctx <- fmInit dpr
 
   validFonts <- foldM (loadFont ctx) [] fonts
 
   when (null validFonts) $
     putStrLn "Could not find any valid fonts. Text size calculations will fail."
 
-  return $ newManager ctx adjustedDpr
+  return $ newManager ctx
 
-newManager :: FMContext -> Double -> FontManager
-newManager ctx dpr = FontManager {..} where
-  computeTextMetrics font fontSize = unsafePerformIO $ do
-    setFont ctx dpr font fontSize def
+newManager :: FMContext -> FontManager
+newManager ctx = FontManager {..} where
+  computeTextMetrics font fontSize =
+    computeTextMetrics_ 1 font fontSize
+
+  computeTextMetrics_ scale font fontSize = unsafePerformIO $ do
+    setFont ctx scale font fontSize def
     (asc, desc, lineh) <- fmTextMetrics ctx
     lowerX <- Seq.lookup 0 <$> fmTextGlyphPositions ctx 0 0 "x"
     let heightLowerX = case lowerX of
@@ -64,24 +58,30 @@ newManager ctx dpr = FontManager {..} where
           Nothing -> realToFrac asc
 
     return $ TextMetrics {
-      _txmAsc = asc / dpr,
-      _txmDesc = desc / dpr,
-      _txmLineH = lineh / dpr,
-      _txmLowerX = realToFrac heightLowerX / dpr
+      _txmAsc = asc,
+      _txmDesc = desc,
+      _txmLineH = lineh,
+      _txmLowerX = realToFrac heightLowerX
     }
 
-  computeTextSize font fontSize fontSpaceH text = unsafePerformIO $ do
-    setFont ctx dpr font fontSize fontSpaceH
+  computeTextSize font fontSize fontSpaceH text =
+    computeTextSize_ 1 font fontSize fontSpaceH text
+
+  computeTextSize_ scale font fontSize fontSpaceH text = unsafePerformIO $ do
+    setFont ctx scale font fontSize fontSpaceH
     (x1, y1, x2, y2) <- if text /= ""
       then fmTextBounds ctx 0 0 text
       else do
         (asc, desc, lineh) <- fmTextMetrics ctx
         return (0, 0, 0, lineh)
 
-    return $ Size (realToFrac (x2 - x1) / dpr) (realToFrac (y2 - y1) / dpr)
+    return $ Size (realToFrac (x2 - x1)) (realToFrac (y2 - y1))
 
-  computeGlyphsPos font fontSize fontSpaceH text = unsafePerformIO $ do
-    setFont ctx dpr font fontSize fontSpaceH
+  computeGlyphsPos font fontSize fontSpaceH text =
+    computeGlyphsPos_ 1 font fontSize fontSpaceH text
+
+  computeGlyphsPos_ scale font fontSize fontSpaceH text = unsafePerformIO $ do
+    setFont ctx scale font fontSize fontSpaceH
     glyphs <- if text /= ""
       then fmTextGlyphPositions ctx 0 0 text
       else return Seq.empty
@@ -90,12 +90,12 @@ newManager ctx dpr = FontManager {..} where
     where
       toGlyphPos chr glyph = GlyphPos {
         _glpGlyph = chr,
-        _glpXMin = realToFrac (glyphPosMinX glyph) / dpr,
-        _glpXMax = realToFrac (glyphPosMaxX glyph) / dpr,
-        _glpYMin = realToFrac (glyphPosMinY glyph) / dpr,
-        _glpYMax = realToFrac (glyphPosMaxY glyph) / dpr,
-        _glpW = realToFrac (glyphPosMaxX glyph - glyphPosMinX glyph) / dpr,
-        _glpH = realToFrac (glyphPosMaxY glyph - glyphPosMinY glyph) / dpr
+        _glpXMin = realToFrac (glyphPosMinX glyph),
+        _glpXMax = realToFrac (glyphPosMaxX glyph),
+        _glpYMin = realToFrac (glyphPosMinY glyph),
+        _glpYMax = realToFrac (glyphPosMaxY glyph),
+        _glpW = realToFrac (glyphPosMaxX glyph - glyphPosMinX glyph),
+        _glpH = realToFrac (glyphPosMaxY glyph - glyphPosMinY glyph)
       }
 
 loadFont :: FMContext -> [Text] -> FontDef -> IO [Text]
@@ -106,7 +106,8 @@ loadFont ctx fonts (FontDef name path) = do
     else putStrLn ("Failed to load font: " ++ T.unpack name) >> return fonts
 
 setFont :: FMContext -> Double -> Font -> FontSize -> FontSpace -> IO ()
-setFont ctx dpr (Font name) (FontSize size) (FontSpace spaceH) = do
+setFont ctx scale (Font name) (FontSize size) (FontSpace spaceH) = do
+  fmSetScale ctx scale
   fmFontFace ctx name
-  fmFontSize ctx $ realToFrac $ size * dpr
-  fmTextLetterSpacing ctx $ realToFrac $ spaceH * dpr
+  fmFontSize ctx $ realToFrac size
+  fmTextLetterSpacing ctx $ realToFrac spaceH

--- a/src/Monomer/Graphics/Text.hs
+++ b/src/Monomer/Graphics/Text.hs
@@ -279,8 +279,8 @@ fitLineToW fontMgr font fSize fSpcH fSpcV metrics break top width trim text = re
     | break == OnCharacters = splitGroups break width glyphs
     | otherwise = fitGroups (splitGroups break width glyphs) width keepTailSpaces
   resetGroups
-    | trim == TrimSpaces = fmap (resetGlyphs . trimGlyphs) groups
-    | otherwise = fmap resetGlyphs groups
+    | trim == TrimSpaces = fmap trimGlyphs groups
+    | otherwise = groups
   buildLine = buildTextLine font fSize fSpcH fSpcV metrics top
   res
     | text /= "" = Seq.mapWithIndex buildLine resetGroups
@@ -428,18 +428,6 @@ splitGroups break width glyphs = group <| splitGroups break width rest where
     | atWord && isWordDelimiter (_glpGlyph g) = (Seq.singleton g, gs)
     | atWord = Seq.spanl groupWordFn glyphs
     | otherwise = Seq.spanl groupWidthFn glyphs
-
-resetGlyphs :: Seq GlyphPos -> Seq GlyphPos
-resetGlyphs Empty = Empty
-resetGlyphs gs@(g :<| _) = resetGlyphsPos gs (_glpXMin g)
-
-resetGlyphsPos :: Seq GlyphPos -> Double -> Seq GlyphPos
-resetGlyphsPos Empty _ = Empty
-resetGlyphsPos (g :<| gs) offset = newG <| resetGlyphsPos gs offset where
-  newG = g {
-    _glpXMin = _glpXMin g - offset,
-    _glpXMax = _glpXMax g - offset
-  }
 
 trimGlyphs :: Seq GlyphPos -> Seq GlyphPos
 trimGlyphs glyphs = newGlyphs where

--- a/src/Monomer/Graphics/Types.hs
+++ b/src/Monomer/Graphics/Types.hs
@@ -140,6 +140,7 @@ instance Default AlignTV where
 -- | Information of a text glyph instance.
 data GlyphPos = GlyphPos {
   _glpGlyph :: {-# UNPACK #-} !Char,   -- ^ The represented character.
+  _glpX :: {-# UNPACK #-} !Double,     -- ^ The x coordinate used for rendering.
   _glpXMin :: {-# UNPACK #-} !Double,  -- ^ The min x coordinate.
   _glpXMax :: {-# UNPACK #-} !Double,  -- ^ The max x coordinate.
   _glpYMin :: {-# UNPACK #-} !Double,  -- ^ The min x coordinate.
@@ -151,6 +152,7 @@ data GlyphPos = GlyphPos {
 instance Default GlyphPos where
   def = GlyphPos {
     _glpGlyph = ' ',
+    _glpX = 0,
     _glpXMin = 0,
     _glpXMax = 0,
     _glpYMin = 0,
@@ -197,8 +199,8 @@ instance Default TextMetrics where
 data TextLine = TextLine {
   _tlFont :: !Font,              -- ^ The font name.
   _tlFontSize :: !FontSize,      -- ^ The font size.
-  _tlFontSpaceH :: !FontSpace, -- ^ The font spacing.
-  _tlFontSpaceV :: !FontSpace, -- ^ The vertical line spacing.
+  _tlFontSpaceH :: !FontSpace,   -- ^ The font spacing.
+  _tlFontSpaceV :: !FontSpace,   -- ^ The vertical line spacing.
   _tlMetrics :: !TextMetrics,    -- ^ The text metrics for the given font/size.
   _tlText :: !Text,              -- ^ The represented text.
   _tlSize :: !Size,              -- ^ The size the formatted text takes.
@@ -228,7 +230,7 @@ data ImageFlag
 
 -- | The definition of a loaded image.
 data ImageDef = ImageDef {
-  _idfName :: Text,            -- ^ The logic name of the image.
+  _idfName :: Text,              -- ^ The logic name of the image.
   _idfSize :: Size,              -- ^ The dimensions of the image.
   _idfImgData :: BS.ByteString,  -- ^ The image data as RGBA 4-bytes blocks.
   _idfFlags :: [ImageFlag]       -- ^ The image flags.

--- a/src/Monomer/Graphics/Types.hs
+++ b/src/Monomer/Graphics/Types.hs
@@ -234,14 +234,33 @@ data ImageDef = ImageDef {
   _idfFlags :: [ImageFlag]       -- ^ The image flags.
 } deriving (Eq, Show, Generic)
 
--- | Text metrics related functions.
+{-|
+Text metrics related functions.
+
+Two different versions of each function exist:
+
+- Default one, without underscore, does not apply scaling.
+- Version with a trailing underscore, that receives an extra scale argument.
+
+In case the text is going to be rendered with a scale factor applied on
+'Renderer' (by calling 'setScale'), it is recommended to apply the scale here
+too (otherwise there will be differences in size and positioning). In most use
+cases these functions will never be called, preferring the non underscore
+versions.
+-}
 data FontManager = FontManager {
   -- | Returns the text metrics of a given font and size.
   computeTextMetrics :: Font -> FontSize -> TextMetrics,
+  -- | Returns the text metrics of a given font and size, applying scale.
+  computeTextMetrics_ :: Double -> Font -> FontSize -> TextMetrics,
   -- | Returns the size of the line of text given font and size.
   computeTextSize :: Font -> FontSize -> FontSpace -> Text -> Size,
+  -- | Returns the size of the line of text given font and size, applying scale.
+  computeTextSize_ :: Double -> Font -> FontSize -> FontSpace -> Text -> Size,
   -- | Returns the glyphs of the line of text given font and size.
-  computeGlyphsPos :: Font -> FontSize -> FontSpace -> Text -> Seq GlyphPos
+  computeGlyphsPos :: Font -> FontSize -> FontSpace -> Text -> Seq GlyphPos,
+  -- | Returns the glyphs of the line of text given font and size, applying scale.
+  computeGlyphsPos_ :: Double -> Font -> FontSize -> FontSpace -> Text -> Seq GlyphPos
 }
 
 -- | Low level rendering definitions.

--- a/src/Monomer/Widgets/Singles/Base/InputField.hs
+++ b/src/Monomer/Widgets/Singles/Base/InputField.hs
@@ -760,7 +760,7 @@ findClosestGlyphPos state point = newPos where
   textLen = getGlyphsMax (_ifsGlyphs state)
   glyphs
     | Seq.null (_ifsGlyphs state) = Seq.empty
-    | otherwise = _ifsGlyphs state |> GlyphPos ' ' textLen 0 0 0 0 0 0
+    | otherwise = _ifsGlyphs state |> GlyphPos ' ' 0 textLen 0 0 0 0 0
   glyphStart i g = (i, abs (_glpXMin g - localX))
   pairs = Seq.mapWithIndex glyphStart glyphs
   cpm (_, g1) (_, g2) = compare g1 g2

--- a/src/Monomer/Widgets/Singles/Base/InputField.hs
+++ b/src/Monomer/Widgets/Singles/Base/InputField.hs
@@ -760,7 +760,7 @@ findClosestGlyphPos state point = newPos where
   textLen = getGlyphsMax (_ifsGlyphs state)
   glyphs
     | Seq.null (_ifsGlyphs state) = Seq.empty
-    | otherwise = _ifsGlyphs state |> GlyphPos ' ' textLen 0 0 0 0 0
+    | otherwise = _ifsGlyphs state |> GlyphPos ' ' textLen 0 0 0 0 0 0
   glyphStart i g = (i, abs (_glpXMin g - localX))
   pairs = Seq.mapWithIndex glyphStart glyphs
   cpm (_, g1) (_, g2) = compare g1 g2

--- a/src/Monomer/Widgets/Singles/TextArea.hs
+++ b/src/Monomer/Widgets/Singles/TextArea.hs
@@ -919,7 +919,7 @@ findClosestGlyphPos state point = (newPos, lineIdx) where
 
   glyphs
     | Seq.null lineGlyphs = Seq.empty
-    | otherwise = lineGlyphs |> GlyphPos ' ' textLen 0 0 0 0 0
+    | otherwise = lineGlyphs |> GlyphPos ' ' textLen 0 0 0 0 0 0
   glyphStart i g = (i, abs (_glpXMin g - x))
 
   pairs = Seq.mapWithIndex glyphStart glyphs

--- a/src/Monomer/Widgets/Singles/TextArea.hs
+++ b/src/Monomer/Widgets/Singles/TextArea.hs
@@ -919,7 +919,7 @@ findClosestGlyphPos state point = (newPos, lineIdx) where
 
   glyphs
     | Seq.null lineGlyphs = Seq.empty
-    | otherwise = lineGlyphs |> GlyphPos ' ' textLen 0 0 0 0 0 0
+    | otherwise = lineGlyphs |> GlyphPos ' ' 0 textLen 0 0 0 0 0
   glyphStart i g = (i, abs (_glpXMin g - x))
 
   pairs = Seq.mapWithIndex glyphStart glyphs

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,7 @@ packages:
 extra-deps:
   - nanovg-0.8.0.0@sha256:0183b4295ccc2dfb94a7eca977fb45759e1480652578936aa7b71bb4b9626480,4742
 
-  # Override default flag values for local packages and extra-deps
+# Override default flag values for local packages and extra-deps
 flags:
   nanovg:
     stb_truetype: true

--- a/test/unit/Monomer/TestUtil.hs
+++ b/test/unit/Monomer/TestUtil.hs
@@ -56,27 +56,35 @@ testWindowSize = Size testW testH
 testWindowRect :: Rect
 testWindowRect = Rect 0 0 testW testH
 
-mockTextMetrics :: Font -> FontSize -> TextMetrics
-mockTextMetrics font fontSize = TextMetrics {
+mockTextMetrics :: Double -> Font -> FontSize -> TextMetrics
+mockTextMetrics scale font fontSize = TextMetrics {
   _txmAsc = 15,
   _txmDesc = 5,
   _txmLineH = 20,
   _txmLowerX = 10
 }
 
-mockTextSize :: Maybe Double -> Font -> FontSize -> FontSpace -> Text -> Size
-mockTextSize mw font (FontSize fs) spaceH text = Size width height where
+mockTextSize
+  :: Maybe Double -> Double -> Font -> FontSize -> FontSpace -> Text -> Size
+mockTextSize mw scale font (FontSize fs) spaceH text = Size width height where
   w = fromMaybe fs mw + unFontSpace spaceH
   width = fromIntegral (T.length text) * w
   height = 20
 
 mockGlyphsPos
-  :: Maybe Double -> Font -> FontSize -> FontSpace -> Text -> Seq GlyphPos
-mockGlyphsPos mw font (FontSize fs) spaceH text = glyphs where
+  :: Maybe Double
+  -> Double
+  -> Font
+  -> FontSize
+  -> FontSpace
+  -> Text
+  -> Seq GlyphPos
+mockGlyphsPos mw scale font (FontSize fs) spaceH text = glyphs where
   w = fromMaybe fs mw + unFontSpace spaceH
   chars = Seq.fromList $ T.unpack text
   mkGlyph idx chr = GlyphPos {
     _glpGlyph = chr,
+    _glpX = fromIntegral idx * w,
     _glpXMin = fromIntegral idx * w,
     _glpXMax = (fromIntegral idx + 1) * w,
     _glpYMin = 0,
@@ -154,9 +162,12 @@ mockRenderer = Renderer {
 
 mockFontManager :: FontManager
 mockFontManager = FontManager {
-  computeTextMetrics = mockTextMetrics,
-  computeTextSize = mockTextSize (Just 10),
-  computeGlyphsPos = mockGlyphsPos (Just 10)
+  computeTextMetrics = mockTextMetrics 1,
+  computeTextMetrics_ = mockTextMetrics,
+  computeTextSize = mockTextSize (Just 10) 1,
+  computeTextSize_ = mockTextSize (Just 10),
+  computeGlyphsPos = mockGlyphsPos (Just 10) 1,
+  computeGlyphsPos_ = mockGlyphsPos (Just 10)
 }
 
 mockWenv :: s -> WidgetEnv s e

--- a/test/unit/Monomer/Widgets/Singles/LabelSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/LabelSpec.hs
@@ -121,7 +121,7 @@ getSizeReqMerge = describe "getSizeReqMerge" $ do
 
   where
     fontMgr = mockFontManager {
-      computeGlyphsPos = mockGlyphsPos Nothing
+      computeGlyphsPos = mockGlyphsPos Nothing 1
     }
     wenv = mockWenvEvtUnit ()
       & L.fontManager .~ fontMgr


### PR DESCRIPTION
`FontManager`, Haskell side, had duplicated scaling logic performed by the C module. This caused issues with size calculations, which then affected right alignment.

Discussed here: https://github.com/fjvallarino/monomer/issues/124.

Added an `x` attribute to `GlyphPos`, which should be used when manually rendering glyphs (using `xMin` will cause positioning issues).

Discussed in this issue: https://github.com/fjvallarino/monomer/issues/101.
