### PR TITLE
Allow disabling scale detection

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,7 @@
 - `compositeMergeEvents`, for completeness ([PR #114](https://github.com/fjvallarino/monomer/pull/114)).
 - Support for symbols and other keys in `keystroke` ([PR #117](https://github.com/fjvallarino/monomer/pull/117)).
 - New constructor (`buttonD_`) and `ignoreParentEvts` configuration option to `button` ([PR #123](https://github.com/fjvallarino/monomer/pull/123)).
+- Allow disabling auto scale detection with `appDisableAutoScale` ([PR #128](https://github.com/fjvallarino/monomer/pull/128)).
 
 ### Changed
 

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -217,7 +217,7 @@ getDisplayDPI =
 
 -- | Returns the default resize factor for Windows.
 getWindowsFactor :: IO Double
-getWindowsFactor = getDisplayDPIFactor
+getWindowsFactor = max 1 <$> getDisplayDPIFactor
 
 -- | Returns the default resize factor for Linux.
 getLinuxFactor :: IO Double

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -215,23 +215,11 @@ getDisplayDPI =
         vdpi <- peek pvdpi
         return (realToFrac ddpi, realToFrac hdpi, realToFrac vdpi)
 
--- | Returns the default resize factor for Windows
+-- | Returns the default resize factor for Windows.
 getWindowsFactor :: IO Double
 getWindowsFactor = getDisplayDPIFactor
 
-{-|
-Returns a scale factor to handle HiDPI on Linux.
-
-Assumes that resolutions larger than 1920 belong to HiDPI displays and scales
-them by 2. In case this is not an appropriate scale, 'appScaleFactor' can be
-used to set a custom scaling factor, while 'appDisableAutoScale' can be used for
-disabling automatic detection.
-
-There is not a practical DPI/scale detection solution that works for all
-combinations of Linux display servers and window managers. For a reference of
-some of the existing options for detection, check here:
-https://wiki.archlinux.org/title/HiDPI.
--}
+-- | Returns the default resize factor for Linux.
 getLinuxFactor :: IO Double
 getLinuxFactor = do
   dpiFactor <- getDisplayDPIFactor
@@ -248,7 +236,7 @@ getLinuxFactor = do
 
     return detectedDPI
 
--- | Returns DPI scaling factor using SDL_GetDisplayDPI
+-- | Returns DPI scaling factor using SDL_GetDisplayDPI.
 getDisplayDPIFactor :: IO Double
 getDisplayDPIFactor = do
   (ddpi, hdpi, vdpi) <- getDisplayDPI

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -318,12 +318,12 @@ appScaleFactor factor = def {
 
 {-|
 Whether display scaling detection should not be attempted. If set to True, the
-display scale will be set to 1.
+display scale will be set to 1. This flag does not cause an effect on macOS.
 
 Disabling auto scaling also affects window size on Linux and Windows in the
 cases where the library would have applied scaling. This happens because window
 and viewport size are the same in those operating systems. Window size can be
-adjusted with 'appWindowState'. This flag does not cause an effect on macOS.
+adjusted with 'appWindowState'.
 
 The logic for detecting display scaling varies depending on the platform:
 
@@ -338,7 +338,7 @@ Windows and Linux return the same value for window and viewport size.
 __Windows__
 
 SDL_GetDisplayDPI returns the DPI of the screen, and dividing by 96 gives the
-scaling factor. This factor is used to scale the window and the content.
+scaling factor. This factor is used to scale the window size and the content.
 
 __Linux__
 
@@ -347,12 +347,12 @@ valid information. There is not a practical DPI/scale detection solution that
 works for all combinations of Linux display servers and window managers. Even
 when using the most popular window managers, the scaling factor may be handled
 differently by the distribution (GNOME in Ubuntu). For a reference of some of
-the existing options for detection, check here:
+the existing options for DPI scaling detection, check here:
 https://wiki.archlinux.org/title/HiDPI.
 
-Considering the above, when SDL_GetDisplayDPI fails, the library assumes that
-resolutions larger than 1920 belong to HiDPI displays and scales them by 2. This
-factor is used to scale the window and the content.
+Considering the above, when SDL_GetDisplayDPI fails, the library assumes that a
+screen width larger than 1920 belongs to an HiDPI display and uses a scale
+factor of 2. This factor is used to scale the window size and the content.
 -}
 appDisableAutoScale :: Bool -> AppConfig e
 appDisableAutoScale disable = def {

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -338,8 +338,7 @@ the existing options for detection, check here:
 https://wiki.archlinux.org/title/HiDPI.
 
 Considering the above, the library assumes that resolutions larger than 1920
-belong to HiDPI displays and scales them by 2. This can be disabled using
-'appDisableAutoScale'.
+belong to HiDPI displays and scales them by 2.
 -}
 appScaleFactor :: Double -> AppConfig e
 appScaleFactor factor = def {
@@ -349,6 +348,11 @@ appScaleFactor factor = def {
 {-|
 Whether display scaling detection should not be attempted. If set to True, the
 display scale will be set to 1.
+
+Disabling auto scaling also affects window size on Linux and Windows in the
+cases where the library would have applied scaling. This happens because window
+and viewport size are the same in those operating systems. Window size can be
+adjusted with 'appWindowState'.
 
 This flag works together with 'appScaleFactor', and it does not cause an effect
 on macOS.

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -307,38 +307,9 @@ appMaxFps fps = def {
 }
 
 {-|
-Scale factor to apply. This factor only affects the content, not the size of the
-window. It is applied in addition to the detected display scaling, and can be
-useful if the detected value is not the desired. This can be combined with
-'appDisableAutoScale'.
-
-The logic for detecting display scaling varies depending on the platform.
-
-__macOS__
-
-This can be detected based on the window size and viewport size; the ratio
-between these two give the scaling factor.
-
-Using window and viewport size for detecting DPI only works on macOS; both
-Windows and Linux return the same value window and viewport size.
-
-__Windows__
-
-SDL_GetDisplayDPI returns the DPI of the screen, and dividing by 96 gives the
-scaling factor.
-
-__Linux__
-
-On Linux the situation is more complex, since SDL_GetDisplayDPI does not return
-valid information. There is not a practical DPI/scale detection solution that
-works for all combinations of Linux display servers and window managers. Even
-when using the main window managers the scaling factor may be handled
-differently by the distribution (GNOME in Ubuntu). For a reference of some of
-the existing options for detection, check here:
-https://wiki.archlinux.org/title/HiDPI.
-
-Considering the above, the library assumes that resolutions larger than 1920
-belong to HiDPI displays and scales them by 2.
+Scale factor to apply to the viewport. This factor only affects the content, not
+the size of the window. It is applied in addition to the detected display scale
+factor, and can be useful if the detected value is not the desired.
 -}
 appScaleFactor :: Double -> AppConfig e
 appScaleFactor factor = def {
@@ -352,10 +323,36 @@ display scale will be set to 1.
 Disabling auto scaling also affects window size on Linux and Windows in the
 cases where the library would have applied scaling. This happens because window
 and viewport size are the same in those operating systems. Window size can be
-adjusted with 'appWindowState'.
+adjusted with 'appWindowState'. This flag does not cause an effect on macOS.
 
-This flag works together with 'appScaleFactor', and it does not cause an effect
-on macOS.
+The logic for detecting display scaling varies depending on the platform:
+
+__macOS__
+
+Scaling can be detected based on the window size and viewport size; the ratio
+between these two give the scaling factor.
+
+Using window and viewport size for detecting DPI only works on macOS; both
+Windows and Linux return the same value for window and viewport size.
+
+__Windows__
+
+SDL_GetDisplayDPI returns the DPI of the screen, and dividing by 96 gives the
+scaling factor. This factor is used to scale the window and the content.
+
+__Linux__
+
+The situation is more complex, since SDL_GetDisplayDPI does not return valid
+information. There is not a practical DPI/scale detection solution that works
+for all combinations of Linux display servers and window managers. Even when
+using the most popular window managers, the scaling factor may be handled
+differently by the distribution (GNOME in Ubuntu). For a reference of some of
+the existing options for detection, check here:
+https://wiki.archlinux.org/title/HiDPI.
+
+Considering the above, the library assumes that resolutions larger than 1920
+belong to HiDPI displays and scales them by 2. This factor is used to scale the
+window and the content.
 -}
 appDisableAutoScale :: Bool -> AppConfig e
 appDisableAutoScale disable = def {

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -342,17 +342,17 @@ scaling factor. This factor is used to scale the window and the content.
 
 __Linux__
 
-The situation is more complex, since SDL_GetDisplayDPI does not return valid
-information. There is not a practical DPI/scale detection solution that works
-for all combinations of Linux display servers and window managers. Even when
-using the most popular window managers, the scaling factor may be handled
+The situation is more complex, since SDL_GetDisplayDPI does not always return
+valid information. There is not a practical DPI/scale detection solution that
+works for all combinations of Linux display servers and window managers. Even
+when using the most popular window managers, the scaling factor may be handled
 differently by the distribution (GNOME in Ubuntu). For a reference of some of
 the existing options for detection, check here:
 https://wiki.archlinux.org/title/HiDPI.
 
-Considering the above, the library assumes that resolutions larger than 1920
-belong to HiDPI displays and scales them by 2. This factor is used to scale the
-window and the content.
+Considering the above, when SDL_GetDisplayDPI fails, the library assumes that
+resolutions larger than 1920 belong to HiDPI displays and scales them by 2. This
+factor is used to scale the window and the content.
 -}
 appDisableAutoScale :: Bool -> AppConfig e
 appDisableAutoScale disable = def {


### PR DESCRIPTION
Adds a configuration flag to disable display scaling detection. This can be useful if the detected display scaling is not correct (mainly on Linux).

It also attempts to use `SDL_GetDisplayDPI` on Linux when auto scaling, even if it may fail. When it fails, it relies on window width to decide if scaling is applied.

Discussed here: https://github.com/fjvallarino/monomer/issues/72
