### PR TITLE
Make radio and optionButton only trigger onChange when the value changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,7 @@
 
 - The `keystroke` widget now supports the `Backspace` key ([PR #74](https://github.com/fjvallarino/monomer/pull/74)).
 - `style...` family of functions now combine new attributes with the existing ones ([PR #104](https://github.com/fjvallarino/monomer/pull/104)).
+- `radio` and `optionButton` now only trigger `onChange` when their value changes. `onClick` was can be used to replicate the previous `onChange` behavior ([PR #134](https://github.com/fjvallarino/monomer/pull/134)).
 
 ### Renamed
 

--- a/src/Monomer/Widgets/Singles/OptionButton.hs
+++ b/src/Monomer/Widgets/Singles/OptionButton.hs
@@ -102,6 +102,7 @@ data OptionButtonCfg s e a = OptionButtonCfg {
   _obcLabelCfg :: LabelCfg s e,
   _obcOnFocusReq :: [Path -> WidgetRequest s e],
   _obcOnBlurReq :: [Path -> WidgetRequest s e],
+  _obcOnClickReq :: [WidgetRequest s e],
   _obcOnChangeReq :: [a -> WidgetRequest s e]
 }
 
@@ -112,6 +113,7 @@ instance Default (OptionButtonCfg s e a) where
     _obcLabelCfg = def,
     _obcOnFocusReq = [],
     _obcOnBlurReq = [],
+    _obcOnClickReq = [],
     _obcOnChangeReq = []
   }
 
@@ -122,6 +124,7 @@ instance Semigroup (OptionButtonCfg s e a) where
     _obcLabelCfg = _obcLabelCfg t1 <> _obcLabelCfg t2,
     _obcOnFocusReq = _obcOnFocusReq t1 <> _obcOnFocusReq t2,
     _obcOnBlurReq = _obcOnBlurReq t1 <> _obcOnBlurReq t2,
+    _obcOnClickReq = _obcOnClickReq t1 <> _obcOnClickReq t2,
     _obcOnChangeReq = _obcOnChangeReq t1 <> _obcOnChangeReq t2
   }
 
@@ -184,6 +187,16 @@ instance WidgetEvent e => CmbOnBlur (OptionButtonCfg s e a) e Path where
 instance CmbOnBlurReq (OptionButtonCfg s e a) s e Path where
   onBlurReq req = def {
     _obcOnBlurReq = [req]
+  }
+
+instance WidgetEvent e => CmbOnClick (OptionButtonCfg s e a) e where
+  onClick req = def {
+    _obcOnClickReq = [RaiseEvent req]
+  }
+
+instance CmbOnClickReq (OptionButtonCfg s e a) s e where
+  onClickReq req = def {
+    _obcOnClickReq = [req]
   }
 
 instance WidgetEvent e => CmbOnChange (OptionButtonCfg s e a) a e where
@@ -344,7 +357,11 @@ makeOptionButton styleOn styleOff !field !caption !isSelVal !getNextVal !config 
       currValue = widgetDataGet (wenv ^. L.model) field
       nextValue = getNextVal currValue
       setValueReq = widgetDataSet field nextValue
-      reqs = setValueReq ++ fmap ($ nextValue) (_obcOnChangeReq config)
+      clickReqs = _obcOnClickReq config
+      changeReqs
+        | currValue /= nextValue = fmap ($ nextValue) (_obcOnChangeReq config)
+        | otherwise = []
+      reqs = setValueReq ++ clickReqs ++ changeReqs
       result = resultReqs node reqs
       resultFocus = resultReqs node [SetFocus (node ^. L.info . L.widgetId)]
 

--- a/src/Monomer/Widgets/Singles/OptionButton.hs
+++ b/src/Monomer/Widgets/Singles/OptionButton.hs
@@ -93,8 +93,10 @@ Configuration options for optionButton:
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.
 - 'onBlurReq': 'WidgetRequest' to generate when focus is lost.
-- 'onChange': event to raise when the value changes/is clicked.
-- 'onChangeReq': 'WidgetRequest' to generate when the value changes/is clicked.
+- 'onClick': event to raise when the value is clicked.
+- 'onClickReq': 'WidgetRequest' to generate when the value is clicked.
+- 'onChange': event to raise when the value changes.
+- 'onChangeReq': 'WidgetRequest' to generate when the value changes.
 -}
 data OptionButtonCfg s e a = OptionButtonCfg {
   _obcIgnoreTheme :: Maybe Bool,

--- a/src/Monomer/Widgets/Singles/ToggleButton.hs
+++ b/src/Monomer/Widgets/Singles/ToggleButton.hs
@@ -62,8 +62,10 @@ Configuration options for toggleButton:
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.
 - 'onBlurReq': 'WidgetRequest' to generate when focus is lost.
-- 'onChange': event to raise when the value changes/is clicked.
-- 'onChangeReq': 'WidgetRequest' to generate when the value changes/is clicked.
+- 'onClick': event to raise when the value is clicked.
+- 'onClickReq': 'WidgetRequest' to generate when the value is clicked.
+- 'onChange': event to raise when the value changes.
+- 'onChangeReq': 'WidgetRequest' to generate when the value changes.
 -}
 type ToggleButtonCfg = OptionButtonCfg
 

--- a/src/Monomer/Widgets/Singles/ToggleButton.hs
+++ b/src/Monomer/Widgets/Singles/ToggleButton.hs
@@ -6,7 +6,7 @@ Maintainer  : fjvallarino@gmail.com
 Stability   : experimental
 Portability : non-portable
 
-Toggle button widget, used for boolean value.
+Toggle button widget, used for boolean values.
 
 @
 toggleButton \"Toggle\" booleanLens

--- a/test/unit/Monomer/Widgets/Singles/RadioSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/RadioSpec.hs
@@ -40,7 +40,8 @@ data Fruit
   deriving (Eq, Show)
 
 data FruitEvt
-  = FruitSel Fruit
+  = FruitClicked
+  | FruitSel Fruit
   | GotFocus Path
   | LostFocus Path
   deriving (Eq, Show)
@@ -75,12 +76,22 @@ handleEvent = describe "handleEvent" $ do
   it "should generate an event when focus is lost" $
     events evtBlur orangeNode `shouldBe` Seq.singleton (LostFocus emptyPath)
 
+  it "should generate multiple click events when clicked, but a single onChange because the value did not change" $ do
+    let evt = evtClick (Point 320 240)
+    let events es = nodeHandleEventEvts wenv es bananaClickNode
+
+    events [evt] `shouldBe` Seq.fromList [FruitClicked, FruitSel Banana]
+    events [evt, evt] `shouldBe` Seq.fromList [FruitClicked, FruitSel Banana, FruitClicked]
+    events [evt, evt, evt] `shouldBe` Seq.fromList [FruitClicked, FruitSel Banana, FruitClicked, FruitClicked]
+
   where
     wenv = mockWenv (TestModel Apple)
       & L.theme .~ darkTheme
     orangeNode = radio_ Orange fruit [onFocus GotFocus, onBlur LostFocus]
     bananaNode :: WidgetNode TestModel FruitEvt
     bananaNode = radio Banana fruit
+    bananaClickNode = radio_ Banana fruit [onClick FruitClicked, onChange FruitSel]
+
     clickModel p node = nodeHandleEventModel wenv [evtClick p] node
     keyModel key node = nodeHandleEventModel wenv [KeyAction def key KeyPressed] node
     events evt node = nodeHandleEventEvts wenv [evt] node

--- a/test/unit/Monomer/Widgets/Singles/ToggleButtonSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/ToggleButtonSpec.hs
@@ -36,7 +36,8 @@ import Monomer.Widgets.Singles.ToggleButton
 import qualified Monomer.Lens as L
 
 data TestEvt
-  = BoolSel Bool
+  = BoolClicked
+  | BoolSel Bool
   | GotFocus Path
   | LostFocus Path
   deriving (Eq, Show)
@@ -70,9 +71,19 @@ handleEvent = describe "handleEvent" $ do
   it "should generate an event when focus is lost" $
     events evtBlur `shouldBe` Seq.singleton (LostFocus emptyPath)
 
+  it "should generate multiple click and change events when clicked, since it toggles between True and False" $ do
+    let evt = evtClick (Point 320 240)
+    let events es = nodeHandleEventEvts wenv es chkClickNode
+
+    events [evt] `shouldBe` Seq.fromList [BoolClicked, BoolSel True]
+    events [evt, evt] `shouldBe` Seq.fromList [BoolClicked, BoolSel True, BoolClicked, BoolSel False]
+    events [evt, evt, evt] `shouldBe` Seq.fromList [BoolClicked, BoolSel True, BoolClicked, BoolSel False, BoolClicked, BoolSel True]
+
   where
     wenv = mockWenv (TestModel False)
     chkNode = toggleButton_ "Toggle" testBool [onFocus GotFocus, onBlur LostFocus]
+    chkClickNode = toggleButton_ "Toggle" testBool [onClick BoolClicked, onChange BoolSel]
+
     clickModel p = nodeHandleEventModel wenv [evtClick p] chkNode
     keyModel key = nodeHandleEventModel wenv [KeyAction def key KeyPressed] chkNode
     events evt = nodeHandleEventEvts wenv [evt] chkNode


### PR DESCRIPTION
Previous behavior had `radio` and `optionButton` trigger the `onChange` event multiple times when activated (click or Enter/Space keypress). This behavior was incorrect since the value only changed once.

The new version only triggers `onChange` when the value changes and adds `onClick` for cases where multiple triggers are still desired.