### PR TITLE
Fix bug where imageMem widgets will not render their new state after merge.

### DIFF
--- a/src/Monomer/Widgets/Singles/Image.hs
+++ b/src/Monomer/Widgets/Singles/Image.hs
@@ -330,7 +330,10 @@ makeImage !imgSource !config !state = widget where
 
     sameImgNode = newNode
       & L.widget .~ makeImage imgSource config oldState
-    newMemReqs = [ RemoveRendererImage prevPath ]
+    newMemReqs = [ 
+        RemoveRendererImage prevPath,
+        ResizeWidgets wid
+      ]
     newImgReqs = [
         RemoveRendererImage prevPath,
         RunTask wid path (handleImageLoad config wenv imgPath)


### PR DESCRIPTION
State changes applied to imageMem widgets would not be rendered until the next render pass. imageMem widgets were also unable to resize themselves after a different sized image was inserted into them. 