### PR TITLE
Fix memory leak in NanoVGRenderer's image initialization. Dispose unused images in image widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@
 - Drawing and theme utility functions ([PR #138](https://github.com/fjvallarino/monomer/pull/138)).
 - `boxFilterEvent` config option, exposing Container's filterEvent functionality ([PR #146](https://github.com/fjvallarino/monomer/pull/146)).
 
+### Fixed
+
+- Bug where memory based image widget would not render their new state after a merge ([PR #147](https://github.com/fjvallarino/monomer/pull/147)). Thanks @CamdenKuwahara!
+- Fix memory leak in NanoVGRenderer's image initialization. Dispose unused images in image widget ([PR #149](https://github.com/fjvallarino/monomer/pull/149)).
+
 ## 1.4.0.0
 
 ### Breaking changes

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -471,7 +471,7 @@ imgIncreaseCount name imagesMap = newImageMap where
 
 imgInsertNew :: Text -> ImageDef -> ImagesMap -> VG.Image -> ImagesMap
 imgInsertNew name imageDef imagesMap nvImg = newImagesMap where
-  image = Image imageDef nvImg 0
+  image = Image imageDef nvImg 1
   newImagesMap = M.insert name image imagesMap
 
 imgDelete :: Text -> ImagesMap -> ImagesMap

--- a/src/Monomer/Widgets/Singles/Image.hs
+++ b/src/Monomer/Widgets/Singles/Image.hs
@@ -48,7 +48,7 @@ import Control.Monad (when)
 import Data.ByteString (ByteString)
 import Data.Char (toLower)
 import Data.Default
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Maybe
 import Data.List (isPrefixOf)
 import Data.Text (Text)
@@ -62,7 +62,7 @@ import Network.Wreq.Session (Session)
 import qualified Codec.Picture as Pic
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Network.Wreq.Session as Sess
 

--- a/test/unit/Monomer/Widgets/Singles/ImageSpec.hs
+++ b/test/unit/Monomer/Widgets/Singles/ImageSpec.hs
@@ -36,10 +36,11 @@ initMergeWidget = describe "init/merge" $ do
   it "should not create a task when merging to the same path" $
     Seq.length reqs2 `shouldBe` 0
 
-  it "should create a task when merging to a different path" $ do
-    Seq.length reqs3 `shouldBe` 2
-    Seq.index reqs3 0 `shouldSatisfy` isRemoveRendererImage
-    Seq.index reqs3 1 `shouldSatisfy` isRunTask
+  it "should create two tasks when merging to a different path" $ do
+    Seq.length reqs3 `shouldBe` 3
+    Seq.index reqs3 0 `shouldSatisfy` isRunTask
+    Seq.index reqs3 1 `shouldSatisfy` isRemoveRendererImage
+    Seq.index reqs3 2 `shouldSatisfy` isRunTask
 
   it "should have one widgetId on init (loading)" $
     ctx1 ^. L.widgetPaths `shouldSatisfy` (== 1) . length


### PR DESCRIPTION
- `NanoVGRenderer` initialized the image count as 0, and when checking if the image needed to be removed, it tested for 1. The initialization should have always been 1.
- The `image` widget was not disposing of old images if the path changed.

Discussed here: https://github.com/fjvallarino/monomer/issues/148
