### PR TITLE
Do not discard previous WidgetRequests during selectList's postMerge call

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+## 1.4.2.0 (in development)
+
+### Fixed
+
+- Issue in `selectList`, which would ignore `WidgetRequest`s made by child widgets ([PR #157](https://github.com/fjvallarino/monomer/pull/157)).
+
 ## 1.4.1.0
 
 ### Added

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -282,8 +282,11 @@ handleResizeWidgets previousStep = do
       paths <- mapM getWidgetIdPath resizeRequests
       let parts = Set.fromDistinctAscList . drop 1 . toList . Seq.inits
       let sets = fold (parts <$> paths)
+      let checkFn path = isChild || isParent where
+            isChild = any (`seqStartsWith` path) paths
+            isParent = path `Set.member` sets
 
-      return (`Set.member` sets)
+      return checkFn
 
 handleAddPendingResize
   :: MonomerM s e m

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -277,16 +277,13 @@ handleResizeWidgets previousStep = do
 
   return (wenv2, root2, reqs <> reqs2)
   where
-    isInBranch path1 path2
-      =  seqStartsWith path1 path2
-      || seqStartsWith path2 path1
-    checkFn paths path = any (isInBranch path) paths
-
     makeResizeCheckFn = do
       resizeRequests <- use L.resizeRequests
       paths <- mapM getWidgetIdPath resizeRequests
+      let parts = Set.fromDistinctAscList . drop 1 . toList . Seq.inits
+      let sets = fold (parts <$> paths)
 
-      return (checkFn paths)
+      return (`Set.member` sets)
 
 handleAddPendingResize
   :: MonomerM s e m

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -277,16 +277,16 @@ handleResizeWidgets previousStep = do
 
   return (wenv2, root2, reqs <> reqs2)
   where
+    isInBranch path1 path2
+      =  seqStartsWith path1 path2
+      || seqStartsWith path2 path1
+    checkFn paths path = any (isInBranch path) paths
+
     makeResizeCheckFn = do
       resizeRequests <- use L.resizeRequests
       paths <- mapM getWidgetIdPath resizeRequests
-      let parts = Set.fromDistinctAscList . drop 1 . toList . Seq.inits
-      let sets = fold (parts <$> paths)
-      let checkFn path = isChild || isParent where
-            isChild = any (`seqStartsWith` path) paths
-            isParent = path `Set.member` sets
 
-      return checkFn
+      return (checkFn paths)
 
 handleAddPendingResize
   :: MonomerM s e m

--- a/src/Monomer/Widgets/Container.hs
+++ b/src/Monomer/Widgets/Container.hs
@@ -647,7 +647,7 @@ mergeWrapper container wenv newNode oldNode = newResult where
   mState = widgetGetState (mNode ^. L.widget) wenv mNode
   postRes = case (,) <$> useState oldState <*> useState mState of
     Just (ost, st) -> mergePostHandler wenv mNode oldNode ost st mResult
-    Nothing -> resultNode (mResult ^. L.node)
+    Nothing -> mResult
 
   tmpResult
     | isResizeAnyResult (Just postRes) = postRes

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -517,9 +517,11 @@ updateResultStyle
 updateResultStyle wenv config result oldState newState = newResult where
   slIdx = _slIdx newState
   hlIdx = _hlIdx newState
-  tmpNode = result ^. L.node
-  (newNode, reqs) = updateStyles wenv config oldState tmpNode slIdx hlIdx
-  newResult = resultReqs newNode reqs
+  WidgetResult prevNode prevReqs = result
+
+  (newNode, reqs) = updateStyles wenv config oldState prevNode slIdx hlIdx
+  newResult = resultNode newNode
+    & L.requests .~ prevReqs <> Seq.fromList reqs
 
 makeItemsList
   :: (WidgetModel s, WidgetEvent e, Eq a)

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -18,6 +18,11 @@ makeRow username = hstack [
 
 customSelect = selectList userLens usernames makeRow
 @
+
+Note: the content of the list will only be updated when the provided items
+change, based on their 'Eq' instance. In case data external to the items is used
+for building the row nodes, 'mergeRequired' may be needed to avoid stale
+content.
 -}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -84,8 +89,11 @@ Configuration options for selectList:
   navigating away from the widget with tab key.
 - 'itemBasicStyle': style of an item in the list when not selected.
 - 'itemSelectedStyle': style of the selected item in the list.
-- 'mergeRequired': whether merging children is required. Useful when select list
-  is part of another widget such as dropdown.
+- 'mergeRequired': whether merging children is required. Useful when the content
+  displayed depends on external data, since changes to data outside the provided
+  list cannot be detected. In general it is recommended to only depend on data
+  contained in the list itself, making sure the 'Eq' instance of the item type
+  is correct.
 -}
 data SelectListCfg s e a = SelectListCfg {
   _slcSelectOnBlur :: Maybe Bool,

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -53,8 +53,8 @@ import TextShow
 
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
+import qualified Data.Text as T
 
-import Monomer.Graphics.Lens
 import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Box
 import Monomer.Widgets.Containers.Scroll
@@ -327,7 +327,12 @@ makeSelectList widgetData items makeRow config state = widget where
       & L.children .~ createSelectListChildren wenv node
 
   mergePost wenv node oldNode oldState newState result = newResult where
+    widgetId = node ^. L.info . L.widgetId
+    resizeReq = mergeChildrenReq wenv node oldNode oldState
+    extraReqs = Seq.fromList [ ResizeWidgets widgetId | resizeReq ]
+
     newResult = updateResultStyle wenv config result oldState newState
+      & L.requests %~ (<> extraReqs)
 
   handleEvent wenv node target evt = case evt of
     ButtonAction _ btn BtnPressed _
@@ -539,5 +544,6 @@ makeItemsList wenv items makeRow config widgetId selected = itemsList where
     clickCfg = onClickReq $ SendMessage widgetId (SelectListClickItem idx)
     itemCfg = [expandContent, clickCfg]
     content = makeRow item
-    newItem = box_ itemCfg (content & L.info . L.style .~ normalStyle)
+      & L.info . L.style .~ normalStyle
+    newItem = box_ itemCfg content
   itemsList = vstack $ Seq.mapWithIndex makeItem items

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -53,7 +53,6 @@ import TextShow
 
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
-import qualified Data.Text as T
 
 import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Box
@@ -327,12 +326,7 @@ makeSelectList widgetData items makeRow config state = widget where
       & L.children .~ createSelectListChildren wenv node
 
   mergePost wenv node oldNode oldState newState result = newResult where
-    widgetId = node ^. L.info . L.widgetId
-    resizeReq = mergeChildrenReq wenv node oldNode oldState
-    extraReqs = Seq.fromList [ ResizeWidgets widgetId | resizeReq ]
-
     newResult = updateResultStyle wenv config result oldState newState
-      & L.requests %~ (<> extraReqs)
 
   handleEvent wenv node target evt = case evt of
     ButtonAction _ btn BtnPressed _

--- a/src/Monomer/Widgets/Singles/Label.hs
+++ b/src/Monomer/Widgets/Singles/Label.hs
@@ -282,18 +282,13 @@ makeLabel config state = widget where
       = fitTextToSize fontMgr style overflow mode trim maxLines size caption
     newTextLines = alignTextLines style alignRect fittedLines
 
-    newGlyphsReq = pw /= cw || ph /= ch || textStyle /= newTextStyle
-    newLines
-      | not newGlyphsReq = textLines
-      | otherwise = newTextLines
-
     (prevTs, prevStep) = prevResize
     needsSndResize = mode == MultiLine && (prevTs /= ts || not prevStep)
 
     newState = state {
       _lstTextStyle = newTextStyle,
       _lstTextRect = crect,
-      _lstTextLines = newLines,
+      _lstTextLines = newTextLines,
       _lstPrevResize = (ts, needsSndResize && prevTs == ts)
     }
     newNode = node


### PR DESCRIPTION
During the merge process, child widgets may make `WidgetRequest`s for different purposes. One of the main ones is `ResizeWidgets`, which the `label` widget uses for recalculating its glyphs.

The `postMerge` step in `selectList`, used by `dropdown`, discarded previous requests and caused visual issues. Resizing the window, which forces label recalculations, showed that the data was still correct.

The fix for the issue is located in `SelectList.hs`. The rest of the changes are minor, unrelated improvements in `Container`.

This is discussed here: https://github.com/fjvallarino/monomer/issues/154.
