### PR TITLE
Add OS-Specific Dialogs for Loading Files and Folders

### DIFF
--- a/Common/BasicTypes.hs
+++ b/Common/BasicTypes.hs
@@ -1,0 +1,209 @@
+{-|
+Module      : Monomer.Common.BasicTypes
+Copyright   : (c) 2018 Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Basic types used across the library.
+-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Monomer.Common.BasicTypes where
+
+import Data.Default
+import Data.Sequence (Seq)
+import GHC.Generics
+
+import qualified Data.Sequence as Seq
+
+-- | An index in the list of children of a widget.
+type PathStep = Int
+-- | A sequence of steps, usually from the root.
+type Path = Seq PathStep
+-- | Resize factor.
+type Factor = Double
+
+-- | Point in the 2D space.
+data Point = Point {
+  _pX :: {-# UNPACK #-} !Double,
+  _pY :: {-# UNPACK #-} !Double
+} deriving (Eq, Show, Generic)
+
+instance Default Point where
+  def = Point 0 0
+
+-- | Width and height, used for size requirements.
+data Size = Size {
+  _sW :: {-# UNPACK #-} !Double,
+  _sH :: {-# UNPACK #-} !Double
+} deriving (Eq, Show, Generic)
+
+instance Default Size where
+  def = Size 0 0
+
+-- | Rectangle, usually representing an area of the screen.
+data Rect = Rect {
+  _rX :: {-# UNPACK #-} !Double,
+  _rY :: {-# UNPACK #-} !Double,
+  _rW :: {-# UNPACK #-} !Double,
+  _rH :: {-# UNPACK #-} !Double
+} deriving (Eq, Show, Generic)
+
+instance Default Rect where
+  def = Rect 0 0 0 0
+
+-- | An empty path.
+emptyPath :: Path
+emptyPath = Seq.empty
+
+-- | The path of the root element.
+rootPath :: Path
+rootPath = Seq.singleton 0
+
+-- | Checks if a point is inside the given rect.
+pointInRect :: Point -> Rect -> Bool
+pointInRect (Point px py) rect = coordInRectH px rect && coordInRectY py rect
+
+-- | Checks if a point is inside the given ellipse.
+pointInEllipse :: Point -> Rect -> Bool
+pointInEllipse (Point px py) rect = ellipseTest <= 1 where
+  Rect rx ry rw rh = rect
+  ew = rw / 2
+  eh = rh / 2
+  cx = rx + ew
+  cy = ry + eh
+  ellipseTest = ((px - cx) ^ 2) / ew ^ 2  + ((py - cy) ^ 2) / eh ^ 2
+
+-- | Adds two points.
+addPoint :: Point -> Point -> Point
+addPoint (Point x1 y1) (Point x2 y2) = Point (x1 + x2) (y1 + y2)
+
+-- | Subtracts one point from another.
+subPoint :: Point -> Point -> Point
+subPoint (Point x1 y1) (Point x2 y2) = Point (x1 - x2) (y1 - y2)
+
+-- | Multiplies the coordinates of a point by the given factor.
+mulPoint :: Double -> Point -> Point
+mulPoint factor (Point x y) = Point (factor * x) (factor * y)
+
+-- | Returns the middle between two points.
+midPoint :: Point -> Point -> Point
+midPoint p1 p2 = interpolatePoints p1 p2 0.5
+
+-- | Returns the point between a and b, f units away from a.
+interpolatePoints :: Point -> Point -> Double -> Point
+interpolatePoints (Point x1 y1) (Point x2 y2) f = newPoint where
+  newPoint = Point (f * x1 + (1 - f) * x2) (f * y1 + (1 - f) * y2)
+
+-- | Negates the coordinates of a point.
+negPoint :: Point -> Point
+negPoint (Point x y) = Point (-x) (-y)
+
+-- | Checks if a coordinate is inside the horizontal range of a rect.
+coordInRectH :: Double -> Rect -> Bool
+coordInRectH px (Rect x y w h) = px >= x && px < x + w
+
+-- | Checks if a coordinate is inside the vertical range of a rect.
+coordInRectY :: Double -> Rect -> Bool
+coordInRectY py (Rect x y w h) = py >= y && py < y + h
+
+-- | Adds width and height to a Size.
+addToSize :: Size -> Double -> Double -> Maybe Size
+addToSize (Size w h) w2 h2 = newSize where
+  nw = w + w2
+  nh = h + h2
+  newSize
+    | nw >= 0 && nh >= 0 = Just $ Size nw nh
+    | otherwise = Nothing
+
+-- | Subtracts width and height from a Size.
+subtractFromSize :: Size -> Double -> Double -> Maybe Size
+subtractFromSize (Size w h) w2 h2 = newSize where
+  nw = w - w2
+  nh = h - h2
+  newSize
+    | nw >= 0 && nh >= 0 = Just $ Size nw nh
+    | otherwise = Nothing
+
+-- | Moves a rect by the provided offset.
+moveRect :: Point -> Rect -> Rect
+moveRect (Point x y) (Rect rx ry rw rh) = Rect (rx + x) (ry + y) rw rh
+
+-- | Scales a rect by the provided factor.
+mulRect :: Double -> Rect -> Rect
+mulRect f (Rect rx ry rw rh) = Rect (f * rx) (f * ry) (f * rw) (f * rh)
+
+-- | Returns the middle point of a rect.
+rectCenter :: Rect -> Point
+rectCenter (Rect rx ry rw rh) = Point (rx + rw / 2) (ry + rh / 2)
+
+-- | Checks if a rectangle is completely inside a rect.
+rectInRect :: Rect -> Rect -> Bool
+rectInRect inner outer = rectInRectH inner outer && rectInRectV inner outer
+
+-- | Checks if a rectangle is completely inside a rectangle horizontal area.
+rectInRectH :: Rect -> Rect -> Bool
+rectInRectH (Rect x1 y1 w1 h1) (Rect x2 y2 w2 h2) =
+  x1 >= x2 && x1 + w1 <= x2 + w2
+
+-- | Checks if a rectangle is completely inside a rectangle vertical area.
+rectInRectV :: Rect -> Rect -> Bool
+rectInRectV (Rect x1 y1 w1 h1) (Rect x2 y2 w2 h2) =
+  y1 >= y2 && y1 + h1 <= y2 + h2
+
+-- | Checks if a rectangle overlaps another rectangle.
+rectsOverlap :: Rect -> Rect -> Bool
+rectsOverlap (Rect x1 y1 w1 h1) (Rect x2 y2 w2 h2) = overlapX && overlapY where
+  overlapX = x1 < x2 + w2 && x1 + w1 > x2
+  overlapY = y1 < y2 + h2 && y1 + h1 > y2
+
+-- | Returns a point bounded to the horizontal and vertical limits of a rect.
+rectBoundedPoint :: Rect -> Point -> Point
+rectBoundedPoint (Rect rx ry rw rh) (Point px py) = Point px2 py2 where
+  px2 = max rx . min (rx + rw) $ px
+  py2 = max ry . min (ry + rh) $ py
+
+-- | Returns a rect using the provided points as boundaries
+rectFromPoints :: Point -> Point -> Rect
+rectFromPoints (Point x1 y1) (Point x2 y2) = Rect x y w h where
+  x = min x1 x2
+  y = min y1 y2
+  w = abs (x2 - x1)
+  h = abs (y2 - y1)
+
+-- | Adds individual x, y, w and h coordinates to a rect.
+addToRect :: Rect -> Double -> Double -> Double -> Double -> Maybe Rect
+addToRect (Rect x y w h) l r t b = newRect where
+  nx = x - l
+  ny = y - t
+  nw = w + l + r
+  nh = h + t + b
+  newRect
+    | nw >= 0 && nh >= 0 = Just $ Rect nx ny nw nh
+    | otherwise = Nothing
+
+-- | Subtracts individual x, y, w and h coordinates from a rect.
+subtractFromRect :: Rect -> Double -> Double -> Double -> Double -> Maybe Rect
+subtractFromRect (Rect x y w h) l r t b = newRect where
+  nx = x + l
+  ny = y + t
+  nw = w - l - r
+  nh = h - t - b
+  newRect
+    | nw >= 0 && nh >= 0 = Just $ Rect nx ny nw nh
+    | otherwise = Nothing
+
+-- | Returns the intersection of two rects, if any.
+intersectRects :: Rect -> Rect -> Maybe Rect
+intersectRects (Rect x1 y1 w1 h1) (Rect x2 y2 w2 h2) = newRect where
+  nx1 = max x1 x2
+  nx2 = min (x1 + w1) (x2 + w2)
+  ny1 = max y1 y2
+  ny2 = min (y1 + h1) (y2 + h2)
+  nw = nx2 - nx1
+  nh = ny2 - ny1
+  newRect
+    | nw >= 0 && nh >= 0 = Just $ Rect nx1 ny1 nw nh
+    | otherwise = Nothing

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Beyond the tutorials, a few _real world like_ examples are available:
 - [Generative](docs/examples/04-generative.md)
 - [Custom OpenGL](docs/examples/05-opengl.md)
 
+- OS Dialog:
+
+haskell```
+promptFileDialog -> [ Task $ do
+     sr <- osSelectFileDialog "Select Intake JSON" "./" ["*.json"] "json files" False
+     case sr of 
+       Nothing  -> return InvalidFile -- Failure Event
+       Just val -> return $ ProcessFile val
+]
+```
+
+For more info on how osSelectFileDialog and osSelectFolderDialog work see:
+https://hackage.haskell.org/package/tinyfiledialogs
+
 ### Haddock
 
 You can read the source code's documentation [here](https://hackage.haskell.org/package/monomer).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Beyond the tutorials, a few _real world like_ examples are available:
 
 - OS Dialog:
 
-haskell```
+```haskell
 promptFileDialog -> [ Task $ do
      sr <- osSelectFileDialog "Select Intake JSON" "./" ["*.json"] "json files" False
      case sr of 

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
   - transformers >= 0.5 && < 0.7
   - vector >= 0.12 && < 0.14
   - wreq >= 0.5.2 && < 0.6
+  - tinyfiledialogs
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -51,7 +51,7 @@ dependencies:
   - transformers >= 0.5 && < 0.7
   - vector >= 0.12 && < 0.14
   - wreq >= 0.5.2 && < 0.6
-  - tinyfiledialogs
+  - tinyfiledialogs  > 0.2.0.0 && <= 0.2.1.0
 
 library:
   source-dirs: src

--- a/src/Monomer/Common.hs
+++ b/src/Monomer/Common.hs
@@ -9,7 +9,9 @@ Portability : non-portable
 Common module, including basic types definitions.
 -}
 module Monomer.Common (
-  module Monomer.Common.BasicTypes
+  module Monomer.Common.BasicTypes,
+  module Monomer.Common.OSDialogs
 ) where
 
 import Monomer.Common.BasicTypes
+import Monomer.Common.OSDialogs

--- a/src/Monomer/Common/OSDialogs.hs
+++ b/src/Monomer/Common/OSDialogs.hs
@@ -1,0 +1,16 @@
+
+module Monomer.Common.OSDialogs where
+
+import Data.Text
+import Data.Maybe
+import Graphics.UI.TinyFileDialogs
+
+--OS specific File Dialogs
+osSaveFileDialog :: Text   -> Text -> [Text] -> Text -> IO (Maybe Text)	
+osSaveFileDialog   = saveFileDialog
+
+osSelectFileDialog :: Text -> Text -> [Text] -> Text -> Bool	-> IO (Maybe [Text])	
+osSelectFileDialog = openFileDialog
+
+osSelectFolderDialog :: Text -> Text -> IO (Maybe Text)	
+osSelectFolderDialog = selectFolderDialog

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,6 +45,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - nanovg-0.8.0.0@sha256:0183b4295ccc2dfb94a7eca977fb45759e1480652578936aa7b71bb4b9626480,4742
+  - tinyfiledialogs-0.2.1.0@sha256:118f9fd7b721de68f1e84c8b820784e31140bf34e32f23fd6410fb57914a309c,1905
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
This fork adds Monomer.Common.OSDialogs, a module which allows users to quickly and easily retrieve file paths from their computer ,regardless of OS, and send the contents back into Monomer painlessly. The windows take configs of their own if necessary and can be used like this: 

```haskell
handleEvent ... = 
...
PromptFileDialog -> [ Task $ do
     sr <- osSelectFileDialog "Select Intake JSON" "./" ["*.json"] "json files" False
     case sr of 
       Nothing  -> return InvalidFile -- Failure Event
       Just val -> return $ ProcessFile val
]
ProcessFile file -> [Model $ model & filepath .~ (head file)]
``` 