### PR TITLE
Fix Composite's onDispose event handler

### DIFF
--- a/src/Monomer/Helper.hs
+++ b/src/Monomer/Helper.hs
@@ -57,7 +57,23 @@ seqCatMaybes (x :<| xs) = case x of
 applyFnList :: [a -> a] -> a -> a
 applyFnList fns initial = foldl (flip ($)) initial fns
 
--- | Returns the maximum value of a given floating type.
+{-|
+Returns the minimum value of a given floating type.
+
+Copied from: https://hackage.haskell.org/package/numeric-limits
+-}
+minNumericValue :: (RealFloat a) => a
+minNumericValue = x where
+  n = floatDigits x
+  b = floatRadix x
+  (l, _) = floatRange x
+  x = encodeFloat (b^n - 1) (l - n - 1)
+
+{-|
+Returns the maximum value of a given floating type.
+
+Copied from: https://hackage.haskell.org/package/numeric-limits
+-}
 maxNumericValue :: (RealFloat a) => a
 maxNumericValue = x where
   n = floatDigits x


### PR DESCRIPTION
Events sent to a Composite are, in the end, a wrapped `WidgetRequest` (`RaiseEvent`). All the requests made by widgets are collected and later dispatched by the library's top-level handler to their corresponding targets. This helps maintain the original order of the requests; for example, this allows the mixing of user events and focus change requests in the expected order. The problem when disposing a Composite is that, after it is disposed, there is no available handler for its pending events and the top-level handler will not find a target.

This PR solves this issue by handling the pending events before the Composite is disposed, while keeping the other requests intact. ~It's important to note that the events will be processed before the remaining requests (this should not be an issue in general).~

Discussed here: https://github.com/fjvallarino/monomer/issues/175