### PR TITLE
Do not start event watcher if host OS is Linux

### DIFF
--- a/src/Monomer/Core/Util.hs
+++ b/src/Monomer/Core/Util.hs
@@ -329,9 +329,17 @@ isResizeImmediateResult result = isJust resizeReq where
 isResizeAnyResult :: Maybe (WidgetResult s e) -> Bool
 isResizeAnyResult res = isResizeResult res || isResizeImmediateResult res
 
+-- | Checks if the platform is Linux
+isLinux :: WidgetEnv s e -> Bool
+isLinux wenv = _weOs wenv == "Linux"
+
 -- | Checks if the platform is macOS
 isMacOS :: WidgetEnv s e -> Bool
 isMacOS wenv = _weOs wenv == "Mac OS X"
+
+-- | Checks if the platform is Windows
+isWindows :: WidgetEnv s e -> Bool
+isWindows wenv = _weOs wenv == "Windows"
 
 {-|
 Returns the current time in milliseconds. Adds appStartTs and timestamp fields

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -221,7 +221,9 @@ runAppLoop window glCtx channel widgetRoot config = do
   case setupRes of
     RenderSetupMulti -> do
       liftIO . atomically $ writeTChan channel (MsgInit newWenv newRoot)
-      liftIO $ watchWindowResize channel
+
+      unless (isLinux newWenv) $
+        liftIO $ watchWindowResize channel
     _ -> return ()
 
   let loopArgs = MainLoopArgs {


### PR DESCRIPTION
In macOS and Windows, when a user resizes the main window, the window size change events will not reach the application loop until the user completes the resize process, effectively blocking rendering. This will cause the content to be stretched until the user completes the resize operation. To work around this problem an SDL event watcher is used, allowing the processing of the resize events as they happen.

Interestingly, the blocking behavior does not happen in Linux (i.e., the resize events are received immediately). Having the watcher active causes visual artifacts since the main thread and the watcher request rendering using different viewport sizes. 

This PR disables the event watcher on Linux.

Discussed here: https://github.com/fjvallarino/monomer/issues/180
