### PR TITLE
Add a BoxShadow component.

### DIFF
--- a/examples/todo/TodoTypes.hs
+++ b/examples/todo/TodoTypes.hs
@@ -49,6 +49,7 @@ data TodoAction
   = TodoNone
   | TodoAdding
   | TodoEditing Int
+  | TodoConfirmingDelete Int Todo
   deriving (Eq, Show)
 
 data TodoModel = TodoModel {
@@ -63,6 +64,8 @@ data TodoEvt
   | TodoAdd
   | TodoEdit Int Todo
   | TodoSave Int
+  | TodoConfirmDelete Int Todo
+  | TodoCancelDelete
   | TodoDeleteBegin Int Todo
   | TodoDelete Int Todo
   | TodoShowEdit

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -87,6 +87,7 @@ library
       Monomer.Widgets.Containers.Alert
       Monomer.Widgets.Containers.Base.LabeledItem
       Monomer.Widgets.Containers.Box
+      Monomer.Widgets.Containers.BoxShadow
       Monomer.Widgets.Containers.Confirm
       Monomer.Widgets.Containers.Draggable
       Monomer.Widgets.Containers.Dropdown

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -455,6 +455,7 @@ test-suite monomer-test
       Monomer.Widgets.Animation.SlideSpec
       Monomer.Widgets.CompositeSpec
       Monomer.Widgets.Containers.AlertSpec
+      Monomer.Widgets.Containers.BoxShadowSpec
       Monomer.Widgets.Containers.BoxSpec
       Monomer.Widgets.Containers.ConfirmSpec
       Monomer.Widgets.Containers.DragDropSpec

--- a/src/Monomer/Core/ThemeTypes.hs
+++ b/src/Monomer/Core/ThemeTypes.hs
@@ -54,6 +54,8 @@ instance Default Theme where
 data ThemeState = ThemeState {
   _thsEmptyOverlayStyle :: StyleState,
   _thsShadowColor :: Color,
+  _thsShadowAlignH :: AlignH,
+  _thsShadowAlignV :: AlignV,
   _thsBtnStyle :: StyleState,
   _thsBtnMainStyle :: StyleState,
   _thsCheckboxStyle :: StyleState,
@@ -112,6 +114,8 @@ instance Default ThemeState where
   def = ThemeState {
     _thsEmptyOverlayStyle = def,
     _thsShadowColor = darkGray { _colorA = 0.2 },
+    _thsShadowAlignH = ACenter,
+    _thsShadowAlignV = ABottom,
     _thsBtnStyle = def,
     _thsBtnMainStyle = def,
     _thsCheckboxStyle = def,
@@ -170,6 +174,8 @@ instance Semigroup ThemeState where
   (<>) t1 t2 = ThemeState {
     _thsEmptyOverlayStyle = _thsEmptyOverlayStyle t1 <> _thsEmptyOverlayStyle t2,
     _thsShadowColor = _thsShadowColor t2,
+    _thsShadowAlignH = _thsShadowAlignH t2,
+    _thsShadowAlignV = _thsShadowAlignV t2,
     _thsBtnStyle = _thsBtnStyle t1 <> _thsBtnStyle t2,
     _thsBtnMainStyle = _thsBtnMainStyle t1 <> _thsBtnMainStyle t2,
     _thsCheckboxStyle = _thsCheckboxStyle t1 <> _thsCheckboxStyle t2,

--- a/src/Monomer/Core/ThemeTypes.hs
+++ b/src/Monomer/Core/ThemeTypes.hs
@@ -22,6 +22,7 @@ import qualified Data.Map.Strict as M
 import Monomer.Core.StyleTypes
 import Monomer.Graphics.ColorTable
 import Monomer.Graphics.Types
+import Monomer.Graphics.Util
 
 -- | Theme configuration for each state, plus clear/base color.
 data Theme = Theme {
@@ -52,6 +53,7 @@ instance Default Theme where
 -- | Default theme settings for each widget.
 data ThemeState = ThemeState {
   _thsEmptyOverlayStyle :: StyleState,
+  _thsShadowColor :: Color,
   _thsBtnStyle :: StyleState,
   _thsBtnMainStyle :: StyleState,
   _thsCheckboxStyle :: StyleState,
@@ -109,6 +111,7 @@ data ThemeState = ThemeState {
 instance Default ThemeState where
   def = ThemeState {
     _thsEmptyOverlayStyle = def,
+    _thsShadowColor = darkGray { _colorA = 0.2 },
     _thsBtnStyle = def,
     _thsBtnMainStyle = def,
     _thsCheckboxStyle = def,
@@ -166,6 +169,7 @@ instance Default ThemeState where
 instance Semigroup ThemeState where
   (<>) t1 t2 = ThemeState {
     _thsEmptyOverlayStyle = _thsEmptyOverlayStyle t1 <> _thsEmptyOverlayStyle t2,
+    _thsShadowColor = _thsShadowColor t2,
     _thsBtnStyle = _thsBtnStyle t1 <> _thsBtnStyle t2,
     _thsBtnMainStyle = _thsBtnMainStyle t1 <> _thsBtnMainStyle t2,
     _thsCheckboxStyle = _thsCheckboxStyle t1 <> _thsCheckboxStyle t2,

--- a/src/Monomer/Core/Themes/BaseTheme.hs
+++ b/src/Monomer/Core/Themes/BaseTheme.hs
@@ -65,6 +65,7 @@ data BaseThemeColors = BaseThemeColors {
   dialogText :: Color,
   dialogTitleText :: Color,
   emptyOverlay :: Color,
+  shadow :: Color,
   externalLinkBasic :: Color,
   externalLinkHover :: Color,
   externalLinkFocus :: Color,
@@ -222,6 +223,7 @@ baseBasic :: BaseThemeColors -> ThemeState
 baseBasic themeMod = def
   & L.emptyOverlayStyle .~ bgColor (emptyOverlay themeMod)
   & L.emptyOverlayStyle . L.padding ?~ padding 8
+  & L.shadowColor .~ shadow themeMod
   & L.btnStyle .~ btnStyle themeMod
   & L.btnMainStyle .~ btnMainStyle themeMod
   & L.checkboxWidth .~ 20

--- a/src/Monomer/Core/Themes/SampleThemes.hs
+++ b/src/Monomer/Core/Themes/SampleThemes.hs
@@ -56,6 +56,7 @@ lightThemeColors = BaseThemeColors {
   dialogText = black,
   dialogTitleText = black,
   emptyOverlay = gray07 & L.a .~ 0.8,
+  shadow = gray00 & L.a .~ 0.2,
 
   externalLinkBasic = blue07,
   externalLinkHover = blue08,
@@ -155,6 +156,7 @@ darkThemeColors = BaseThemeColors {
   dialogText = white,
   dialogTitleText = white,
   emptyOverlay = gray05 & L.a .~ 0.8,
+  shadow = gray00 & L.a .~ 0.33,
 
   externalLinkBasic = blue07,
   externalLinkHover = blue08,

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -237,6 +237,10 @@ newRenderer c rdpr envRef = Renderer {..} where
     gradient <- makeRadialGradient c dpr p1 rad1 rad2 color1 color2
     VG.strokePaint c gradient
 
+  setStrokeBoxGradient rect rad feather color1 color2 = do
+    gradient <- makeBoxGradient c dpr rect rad feather color1 color2
+    VG.strokePaint c gradient
+
   setStrokeImagePattern name topLeft size angle alpha = do
     env <- readIORef envRef
 
@@ -257,6 +261,10 @@ newRenderer c rdpr envRef = Renderer {..} where
 
   setFillRadialGradient p1 rad1 rad2 color1 color2 = do
     gradient <- makeRadialGradient c dpr p1 rad1 rad2 color1 color2
+    VG.fillPaint c gradient
+
+  setFillBoxGradient rect rad feather color1 color2 = do
+    gradient <- makeBoxGradient c dpr rect rad feather color1 color2
     VG.fillPaint c gradient
 
   setFillImagePattern name topLeft size angle alpha = do
@@ -396,6 +404,17 @@ makeRadialGradient c dpr center rad1 rad2 color1 color2 = do
     CPoint cx cy = pointToCPoint center dpr
     crad1 = realToFrac rad1
     crad2 = realToFrac rad2
+    col1 = colorToPaint color1
+    col2 = colorToPaint color2
+
+makeBoxGradient
+  :: VG.Context -> Double -> Rect -> Double -> Double -> Color -> Color -> IO VG.Paint
+makeBoxGradient c dpr rect rad feather color1 color2 =
+  VG.boxGradient c cx cy cw ch crad cfeather col1 col2
+  where
+    CRect cx cy cw ch = rectToCRect rect dpr
+    crad = realToFrac $ rad * dpr
+    cfeather = realToFrac $ feather * dpr
     col1 = colorToPaint color1
     col2 = colorToPaint color2
 

--- a/src/Monomer/Graphics/Types.hs
+++ b/src/Monomer/Graphics/Types.hs
@@ -333,6 +333,11 @@ data Renderer = Renderer {
   -}
   setStrokeRadialGradient :: Point -> Double -> Double -> Color -> Color -> IO (),
   {-|
+  Sets a box gradient stroke with box area, corner radius, feather, inner and
+  outer Color
+  -}
+  setStrokeBoxGradient :: Rect -> Double -> Double -> Color -> Color -> IO (),
+  {-|
   Sets an image pattern stroke, with top given by Point, size of a single image
   given by size, rotation and alpha.
   -}
@@ -348,6 +353,11 @@ data Renderer = Renderer {
   inner and outer Color.
   -}
   setFillRadialGradient :: Point -> Double -> Double -> Color -> Color -> IO (),
+  {-|
+  Sets a box gradient fill with box area, corner radius, feather, inner and
+  outer Color
+  -}
+  setFillBoxGradient :: Rect -> Double -> Double -> Color -> Color -> IO (),
   {-|
   Sets an image pattern fill, with top given by Point, size of a single image
   given by size, rotation and alpha.

--- a/src/Monomer/Widgets/Containers/Alert.hs
+++ b/src/Monomer/Widgets/Containers/Alert.hs
@@ -40,16 +40,20 @@ module Monomer.Widgets.Containers.Alert (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (.~))
+import Control.Lens ((&), (.~), (%~))
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)
+
+import qualified Data.Sequence as Seq
 
 import Monomer.Core
 import Monomer.Core.Combinators
 
 import Monomer.Widgets.Composite
+import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Box
+import Monomer.Widgets.Containers.BoxShadow
 import Monomer.Widgets.Containers.Keystroke
 import Monomer.Widgets.Containers.Stack
 import Monomer.Widgets.Singles.Button
@@ -165,7 +169,7 @@ buildUI dialogBody cancelEvt config wenv model = mainTree where
       box_ [alignRight] dismissButton
         & L.info . L.style .~ collectTheme wenv L.dialogButtonsStyle
     ] & L.info . L.style .~ collectTheme wenv L.dialogFrameStyle
-  alertBox = box_ [onClickEmpty cancelEvt] alertTree
+  alertBox = box_ [onClickEmpty cancelEvt] (boxShadow alertTree)
     & L.info . L.style .~ emptyOverlay
   mainTree = keystroke [("Esc", cancelEvt)] alertBox
 

--- a/src/Monomer/Widgets/Containers/BoxShadow.hs
+++ b/src/Monomer/Widgets/Containers/BoxShadow.hs
@@ -68,11 +68,11 @@ boxShadow = boxShadow_ def
 
 -- | Creates a boxShadow around the provided content. Accepts config.
 boxShadow_
-  :: BoxShadowCfg    -- ^ The config options for the boxShadow.
+  :: [BoxShadowCfg]  -- ^ The config options for the boxShadow.
   -> WidgetNode s e  -- ^ The content to display inside the boxShadow.
   -> WidgetNode s e  -- ^ The created boxShadow.
 boxShadow_ config child =
-  defaultWidgetNode "boxShadow" (boxShadowWidget config)
+  defaultWidgetNode "boxShadow" (boxShadowWidget (mconcat config))
    & L.children .~ Seq.singleton child
 
 boxShadowWidget :: BoxShadowCfg -> Widget s e

--- a/src/Monomer/Widgets/Containers/BoxShadow.hs
+++ b/src/Monomer/Widgets/Containers/BoxShadow.hs
@@ -1,0 +1,125 @@
+{-|
+Module      : Monomer.Widgets.Containers.BoxShadow
+Copyright   : (c) 2022 Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+A rectangular drop-shadow. Normally used around alert boxes to give the illusion
+they are floating above the widgets underneath them.
+-}
+{-# LANGUAGE Strict #-}
+
+module Monomer.Widgets.Containers.BoxShadow (
+  -- * Configuration
+  BoxShadowCfg,
+  -- * Constructors
+  boxShadow,
+  boxShadow_
+) where
+
+import Control.Applicative ((<|>))
+import Control.Lens ((&), (.~), (^.))
+import Data.Default
+import Data.Maybe
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+
+import Monomer.Widgets.Container
+
+import qualified Monomer.Lens as L
+
+{-|
+Configuration options for boxShadow:
+
+- 'radius': the radius of the corners of the shadow.
+-}
+newtype BoxShadowCfg = BoxShadowCfg {
+  _bscRadius :: Maybe Double
+}
+
+instance Default BoxShadowCfg where
+  def = BoxShadowCfg {
+    _bscRadius = Nothing
+  }
+
+instance Semigroup BoxShadowCfg where
+  (<>) c1 c2 = BoxShadowCfg {
+    _bscRadius = _bscRadius c1 <|> _bscRadius c2
+  }
+
+instance Monoid BoxShadowCfg where
+  mempty = def
+
+instance CmbRadius BoxShadowCfg where
+  radius r = BoxShadowCfg {
+    _bscRadius = Just r
+  }
+
+-- | Creates a boxShadow around the provided content.
+boxShadow
+  :: WidgetNode s e  -- ^ The content to display inside the boxShadow.
+  -> WidgetNode s e  -- ^ The created boxShadow.
+boxShadow = boxShadow_ def
+
+-- | Creates a boxShadow around the provided content. Accepts config.
+boxShadow_
+  :: BoxShadowCfg    -- ^ The config options for the boxShadow.
+  -> WidgetNode s e  -- ^ The content to display inside the boxShadow.
+  -> WidgetNode s e  -- ^ The created boxShadow.
+boxShadow_ config child =
+  defaultWidgetNode "boxShadow" (boxShadowWidget config)
+   & L.children .~ Seq.singleton child
+
+boxShadowWidget :: BoxShadowCfg -> Widget s e
+boxShadowWidget config = widget where
+  widget = createContainer () def {
+    containerGetSizeReq = getSizeReq,
+    containerResize = resize,
+    containerRender = render
+  }
+
+  shadowRadius = fromMaybe 8 (_bscRadius config)
+  shadowDiameter = shadowRadius * 2
+
+  getSizeReq wenv node children = (sizeReqW, sizeReqH) where
+    sizeReqW = maybe (fixedSize 0) (addFixed shadowDiameter . _wniSizeReqW . _wnInfo) vchild
+    sizeReqH = maybe (fixedSize 0) (addFixed shadowDiameter. _wniSizeReqH . _wnInfo) vchild
+    vchildren = Seq.filter (_wniVisible . _wnInfo) children
+    vchild = Seq.lookup 0 vchildren
+
+  resize wenv node viewport children = (resultNode node, fmap assignArea children) where
+    style = currentStyle wenv node
+    contentArea = fromMaybe def (removeOuterBounds style viewport)
+    offset = -shadowRadius / 4 -- so the light appears to be coming from the top center, like in MacOS
+    assignArea child
+      | visible = moveRect (Point 0 offset) (subtractShadow contentArea)
+      | otherwise = def
+      where
+        visible = (_wniVisible . _wnInfo) child
+  
+  render wenv node renderer = do
+    beginPath renderer
+    setFillBoxGradient renderer (subtractShadow vp) shadowRadius shadowDiameter shadowColor transparent
+    renderRect renderer vp
+    fill renderer
+    where
+      style = currentStyle wenv node
+      vp = getContentArea node style
+      shadowColor = wenv ^. L.theme . L.basic . L.shadowColor
+      transparent = rgba 0 0 0 0
+  
+  subtractShadow (Rect l t w h) = Rect l' t' w' h' where
+    (l', w') = subtractDim l w
+    (t', h') = subtractDim t h
+    subtractDim pos size
+      | size > shadowDiameter = (pos + shadowRadius, size - shadowDiameter)
+      | otherwise = (pos + size / 2, 0)
+
+addFixed :: Double -> SizeReq -> SizeReq
+addFixed f sReq =
+  sReq { _szrFixed = _szrFixed sReq + f }

--- a/src/Monomer/Widgets/Containers/Confirm.hs
+++ b/src/Monomer/Widgets/Containers/Confirm.hs
@@ -57,6 +57,7 @@ import Monomer.Core.Combinators
 
 import Monomer.Widgets.Composite
 import Monomer.Widgets.Containers.Box
+import Monomer.Widgets.Containers.BoxShadow
 import Monomer.Widgets.Containers.Keystroke
 import Monomer.Widgets.Containers.Stack
 import Monomer.Widgets.Singles.Button
@@ -213,7 +214,7 @@ buildUI dialogBody pAcceptEvt pCancelEvt config wenv model = mainTree where
       box_ [alignRight] buttons
         & L.info . L.style <>~ collectTheme wenv L.dialogButtonsStyle
     ] & L.info . L.style .~ collectTheme wenv L.dialogFrameStyle
-  confirmBox = box_ [onClickEmpty cancelEvt] confirmTree
+  confirmBox = box_ [onClickEmpty cancelEvt] (boxShadow confirmTree)
     & L.info . L.style .~ emptyOverlay
   mainTree = keystroke [("Esc", cancelEvt)] confirmBox
 

--- a/test/unit/Monomer/TestUtil.hs
+++ b/test/unit/Monomer/TestUtil.hs
@@ -134,12 +134,14 @@ mockRenderer = Renderer {
   setStrokeWidth = \width -> return (),
   setStrokeLinearGradient = \p1 p2 c1 c2 -> return (),
   setStrokeRadialGradient = \p1 a1 a2 c1 c2 -> return (),
+  setStrokeBoxGradient = \a r f c1 c2 -> return (),
   setStrokeImagePattern = \n1 p1 s1 w1 h1 -> return (),
   -- Fill
   fill = return (),
   setFillColor = \color -> return (),
   setFillLinearGradient = \p1 p2 c1 c2 -> return (),
   setFillRadialGradient = \p1 a1 a2 c1 c2 -> return (),
+  setFillBoxGradient = \a r f c1 c2 -> return (),
   setFillImagePattern = \n1 p1 s1 w1 h1 -> return (),
   -- Drawing
   moveTo = \point -> return (),

--- a/test/unit/Monomer/Widgets/Containers/BoxShadowSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/BoxShadowSpec.hs
@@ -1,0 +1,65 @@
+{-|
+Module      : Monomer.Widgets.Containers.BoxShadowSpec
+Copyright   : (c) 2022 Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for BoxShadow widget.
+-}
+
+module Monomer.Widgets.Containers.BoxShadowSpec (spec) where
+
+import Control.Lens ((^.))
+import Test.Hspec
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+import Monomer.TestUtil
+import Monomer.Widgets.Containers.BoxShadow
+import Monomer.Widgets.Singles.Label
+
+import qualified Monomer.Lens as L
+
+spec :: Spec
+spec = describe "BoxShadow" $ do
+  getSizeReq
+  resize
+
+getSizeReq :: Spec
+getSizeReq = describe "getSizeReq" $ do
+  it "should return child width plus radius on each side" $ do
+    sizeW `shouldBe` fixedSize (6 + 7 * 2)
+
+  it "should return child height plus radius on each side" $ do
+    sizeH `shouldBe` fixedSize (9 + 7 * 2)
+
+  where
+    wenv = mockWenvEvtUnit ()
+    boxShadowNode = boxShadow_ [radius 7] $
+      label "test" `styleBasic` [sizeReqW (fixedSize 6), sizeReqH (fixedSize 9)]
+    (sizeW, sizeH) = nodeGetSizeReq wenv boxShadowNode
+
+resize :: Spec
+resize = describe "resize" $ do
+  it "shadow in middle-center should put child in middle-center" $ do
+    childVp [radius 8, alignMiddle, alignCenter] `shouldBe` Rect 8 8 624 464
+
+  it "shadow in top-left should put child in bottom-right" $ do
+    childVp [radius 8, alignTop, alignLeft] `shouldBe` Rect 10 10 624 464
+
+  it "shadow in bottom-right should put child in top-left" $ do
+    childVp [radius 8, alignBottom, alignRight] `shouldBe` Rect 6 6 624 464
+
+  it "shadow in default location should put child in top-center" $ do
+    childVp [radius 8] `shouldBe` Rect 8 6 624 464
+
+  where
+    wenv = mockWenvEvtUnit ()
+    childVp config = childWidget ^. L.info . L.viewport where
+      node = boxShadow_ config (label "test")
+      initedNode = nodeInit wenv node
+      childWidget = Seq.index (initedNode ^. L.children) 0

--- a/test/unit/Monomer/Widgets/Containers/ConfirmSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/ConfirmSpec.hs
@@ -43,7 +43,7 @@ handleEvent = describe "handleEvent" $ do
     events (Point 500 280) `shouldBe` Seq.singleton AcceptClick
 
   it "should generate a Cancel event when clicking the Cancel button" $
-    events (Point 600 280) `shouldBe` Seq.singleton CancelClick
+    events (Point 590 280) `shouldBe` Seq.singleton CancelClick
 
   it "should not generate a close event when clicking the dialog" $
     events (Point 300 200) `shouldBe` Seq.empty

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -22,6 +22,7 @@ import qualified Monomer.Widgets.Animation.SlideSpec as AnimationSlideSpec
 
 import qualified Monomer.Widgets.Containers.AlertSpec as AlertSpec
 import qualified Monomer.Widgets.Containers.BoxSpec as BoxSpec
+import qualified Monomer.Widgets.Containers.BoxShadowSpec as BoxShadowSpec
 import qualified Monomer.Widgets.Containers.ConfirmSpec as ConfirmSpec
 import qualified Monomer.Widgets.Containers.DragDropSpec as DragDropSpec
 import qualified Monomer.Widgets.Containers.DropdownSpec as DropdownSpec
@@ -115,6 +116,7 @@ containers :: Spec
 containers = describe "Containers" $ do
   AlertSpec.spec
   BoxSpec.spec
+  BoxShadowSpec.spec
   ConfirmSpec.spec
   DragDropSpec.spec
   DropdownSpec.spec


### PR DESCRIPTION
As proposed in issue #203.

## Options for light location (i.e. shadow position)

I don't really have an opinion on this, but here are some options:
 
### Light in the center (original proposal)
![light-at-center](https://user-images.githubusercontent.com/1428731/190855523-8220f4d8-f066-4a93-ab26-e0c7e3bbda05.png)

### Light in the top center (MacOS-ish)
![light-at-top-center-mac-os-style](https://user-images.githubusercontent.com/1428731/190855543-3bef98f4-bc70-45c2-817e-894ac37d82dc.png)

### Light in the top-left (Android Material design ish)
![light-at-top-left](https://user-images.githubusercontent.com/1428731/190855574-673390fb-0e93-46ef-8cab-bd1f380653a3.png)
