### PR TITLE
Fix rendering artifacts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,14 @@
+## 1.5.1.0
+
+### Fixed
+
+- Fix rendering artifacts ([PR #215](https://github.com/fjvallarino/monomer/pull/215)).
+
+### Changed
+
+- Add "examples" flag to optionally build examples and tutorials ([PR #218](https://github.com/fjvallarino/monomer/pull/218)).
+- Use pkg-config for glew linking ([PR #219](https://github.com/fjvallarino/monomer/pull/219)).
+
 ## 1.5.0.0
 
 ### Added

--- a/src/Monomer/Event/Core.hs
+++ b/src/Monomer/Event/Core.hs
@@ -36,6 +36,7 @@ isActionEvent :: SDL.EventPayload -> Bool
 isActionEvent SDL.MouseButtonEvent{} = True
 isActionEvent SDL.MouseWheelEvent{} = True
 isActionEvent SDL.KeyboardEvent{} = True
+isActionEvent SDL.TextEditingEvent{} = True
 isActionEvent SDL.TextInputEvent{} = True
 isActionEvent _ = False
 

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -270,6 +270,7 @@ mainLoop window fontManager config loopArgs = do
   inputStatus <- use L.inputStatus
   mousePos <- liftIO $ getCurrentMousePos epr
   currWinSize <- liftIO $ getViewportSize window dpr
+  prevRenderNeded <- use L.renderRequested
 
   let Size rw rh = windowSize
   let ts = startTs - _mlFrameStartTs
@@ -331,6 +332,8 @@ mainLoop window fontManager config loopArgs = do
         | otherwise = Seq.Empty
   let baseStep = (wenv, _mlWidgetRoot, Seq.empty)
 
+  L.renderRequested .= False
+
   (rqWenv, rqRoot, _) <- handleRequests baseReqs baseStep
   (wtWenv, wtRoot, _) <- handleWidgetTasks rqWenv rqRoot
   (seWenv, seRoot, _) <- handleSystemEvents wtWenv wtRoot baseSystemEvents
@@ -346,11 +349,11 @@ mainLoop window fontManager config loopArgs = do
   -- Rendering
   renderCurrentReq <- checkRenderCurrent startTs _mlLatestRenderTs
 
-  let renderEvent = any isActionEvent eventsPayload
-  let winRedrawEvt = windowResized || windowExposed
-  let renderNeeded = winRedrawEvt || renderEvent || renderCurrentReq
+  let actionEvt = any isActionEvent eventsPayload
+  let windowRenderEvt = windowResized || any isWindowRenderEvent eventsPayload
+  let renderNeeded = windowRenderEvt || actionEvt || renderCurrentReq
 
-  when renderNeeded $ do
+  when (prevRenderNeded || renderNeeded) $ do
     renderMethod <- use L.renderMethod
 
     case renderMethod of
@@ -361,8 +364,13 @@ mainLoop window fontManager config loopArgs = do
 
         liftIO $ renderWidgets window dpr renderer bgColor newWenv newRoot
 
-  -- Used in the next rendering cycle
-  L.renderRequested .= windowResized
+  {-
+  Used in the next rendering cycle.
+
+  Temporary workaround: when rendering is needed, make sure to render the next
+  frame too in order to avoid visual artifacts.
+  -}
+  L.renderRequested .= renderNeeded
 
   let fps = realToFrac _mlMaxFps
   let frameLength = round (1000000 / fps)
@@ -455,6 +463,7 @@ handleRenderMsg window renderer fontMgr state (MsgRender tmpWenv newRoot) = do
   let newWenv = tmpWenv
         & L.fontManager .~ fontMgr
   let color = newWenv ^. L.theme . L.clearColor
+
   renderWidgets window dpr renderer color newWenv newRoot
   return (RenderState dpr newWenv newRoot)
 handleRenderMsg window renderer fontMgr state (MsgResize _) = do
@@ -563,6 +572,18 @@ isWindowExposed eventsPayload = not status where
 isMouseEntered :: [SDL.EventPayload] -> Bool
 isMouseEntered eventsPayload = not status where
   status = null [ e | e@SDL.WindowGainedMouseFocusEvent {} <- eventsPayload ]
+
+isWindowRenderEvent :: SDL.EventPayload -> Bool
+isWindowRenderEvent SDL.WindowShownEvent{} = True
+isWindowRenderEvent SDL.WindowExposedEvent{} = True
+isWindowRenderEvent SDL.WindowMovedEvent{} = True
+isWindowRenderEvent SDL.WindowResizedEvent{} = True
+isWindowRenderEvent SDL.WindowSizeChangedEvent{} = True
+isWindowRenderEvent SDL.WindowMaximizedEvent{} = True
+isWindowRenderEvent SDL.WindowRestoredEvent{} = True
+isWindowRenderEvent SDL.WindowGainedMouseFocusEvent{} = True
+isWindowRenderEvent SDL.WindowGainedKeyboardFocusEvent{} = True
+isWindowRenderEvent _ = False
 
 getCurrentTimestamp :: MonadIO m => m Millisecond
 getCurrentTimestamp = toMs <$> liftIO getCurrentTime

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -270,7 +270,7 @@ mainLoop window fontManager config loopArgs = do
   inputStatus <- use L.inputStatus
   mousePos <- liftIO $ getCurrentMousePos epr
   currWinSize <- liftIO $ getViewportSize window dpr
-  prevRenderNeded <- use L.renderRequested
+  prevRenderNeeded <- use L.renderRequested
 
   let Size rw rh = windowSize
   let ts = startTs - _mlFrameStartTs
@@ -353,7 +353,7 @@ mainLoop window fontManager config loopArgs = do
   let windowRenderEvt = windowResized || any isWindowRenderEvent eventsPayload
   let renderNeeded = windowRenderEvt || actionEvt || renderCurrentReq
 
-  when (prevRenderNeded || renderNeeded) $ do
+  when (prevRenderNeeded || renderNeeded) $ do
     renderMethod <- use L.renderMethod
 
     case renderMethod of

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -281,7 +281,7 @@ handleResizeWidgets previousStep = do
       resizeRequests <- use L.resizeRequests
       paths <- mapM getWidgetIdPath resizeRequests
       let parts = Set.fromDistinctAscList . drop 1 . toList . Seq.inits
-      let sets = fold (parts <$> paths)
+      let sets = foldMap parts paths
 
       return (`Set.member` sets)
 


### PR DESCRIPTION
In some cases, and apparently some configurations (it did not happen on my previous laptop), rendering artifacts would appear as a consequence of an optimization that avoids rendering if:

- It was not requested by a widget
- A mouse/keyboard action (click/key press) did not happen

In particular, an idle window is not re-rendered; the same happens with mouse movement events which do not trigger a explicit render request from a widget.

As a workaround, once a frame render is requested, the library will render the next step too. It still does not render all the frames to reduce CPU usage, but incurs a (small?) penalty. I will investigate further solutions, but this seems to solve the issue for the time being.