### PR TITLE
Add "examples" flag to optionally build examples and tutorials

### DIFF
--- a/.ghcid
+++ b/.ghcid
@@ -1,3 +1,3 @@
---command "stack repl --main-is monomer:exe:tutorial"
+--command "stack repl --main-is monomer:exe:dev-test-app"
 --test ":main"
 --restart=package.yaml

--- a/dev-test-app/Main.hs
+++ b/dev-test-app/Main.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+import Control.Lens
+import Data.Maybe
+import Data.Text (Text)
+import Monomer
+import TextShow
+
+import qualified Monomer.Lens as L
+
+newtype AppModel = AppModel {
+  _clickCount :: Int
+} deriving (Eq, Show)
+
+data AppEvent
+  = AppInit
+  | AppIncrease
+  deriving (Eq, Show)
+
+makeLenses 'AppModel
+
+buildUI
+  :: WidgetEnv AppModel AppEvent
+  -> AppModel
+  -> WidgetNode AppModel AppEvent
+buildUI wenv model = widgetTree where
+  widgetTree = vstack [
+      label "Hello world",
+      spacer,
+      hstack [
+        label $ "Click count: " <> showt (model ^. clickCount),
+        spacer,
+        button "Increase count" AppIncrease
+      ]
+    ] `styleBasic` [padding 10]
+
+handleEvent
+  :: WidgetEnv AppModel AppEvent
+  -> WidgetNode AppModel AppEvent
+  -> AppModel
+  -> AppEvent
+  -> [AppEventResponse AppModel AppEvent]
+handleEvent wenv node model evt = case evt of
+  AppInit -> []
+  AppIncrease -> [Model (model & clickCount +~ 1)]
+
+main :: IO ()
+main = do
+  startApp model handleEvent buildUI config
+  where
+    config = [
+      appWindowTitle "Dev test app",
+      appWindowIcon "./assets/images/icon.png",
+      appTheme darkTheme,
+      appFontDef "Regular" "./assets/fonts/Roboto-Regular.ttf",
+      appInitEvent AppInit
+      ]
+    model = AppModel 0

--- a/docs/tutorials/00-setup.md
+++ b/docs/tutorials/00-setup.md
@@ -135,7 +135,7 @@ git clone https://github.com/fjvallarino/monomer.git
 Then, inside the cloned directory, build the project with:
 
 ```bash
-stack build
+stack build --flag monomer:examples
 ```
 
 In case you have not followed the instructions for the starter project, you

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -31,6 +31,10 @@ source-repository head
   type: git
   location: https://github.com/fjvallarino/monomer
 
+flag examples
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Monomer
@@ -228,6 +232,48 @@ executable books
     , transformers >=0.5 && <0.7
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
+  default-language: Haskell2010
+
+executable dev-test-app
+  main-is: Main.hs
+  other-modules:
+      Paths_monomer
+  hs-source-dirs:
+      dev-test-app
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -threaded
+  build-depends:
+      JuicyPixels >=3.2.9 && <3.5
+    , OpenGLRaw ==3.3.*
+    , async >=2.1 && <2.3
+    , attoparsec >=0.12 && <0.15
+    , base >=4.11 && <5
+    , bytestring >=0.10 && <0.12
+    , bytestring-to-vector ==0.3.*
+    , containers >=0.5.11 && <0.7
+    , data-default >=0.5 && <0.8
+    , exceptions ==0.10.*
+    , extra >=1.6 && <1.9
+    , formatting >=6.0 && <8.0
+    , http-client >=0.6 && <0.9
+    , lens >=4.16 && <6
+    , monomer
+    , mtl >=2.1 && <2.3
+    , nanovg >=0.8.1 && <1.0
+    , process ==1.6.*
+    , sdl2 >=2.5.0 && <2.6
+    , stm ==2.5.*
+    , text >=1.2 && <2.1
+    , text-show >=3.7 && <3.10
+    , time >=1.8 && <1.16
+    , transformers >=0.5 && <0.7
+    , vector >=0.12 && <0.14
+    , wreq >=0.5.2 && <0.6
   default-language: Haskell2010
 
 executable generative
@@ -270,6 +316,10 @@ executable generative
     , transformers >=0.5 && <0.7
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 executable opengl
@@ -310,6 +360,10 @@ executable opengl
     , transformers >=0.5 && <0.7
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 executable ticker
@@ -353,6 +407,10 @@ executable ticker
     , websockets ==0.12.*
     , wreq >=0.5.2 && <0.6
     , wuss >=1.1 && <2.3
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 executable todo
@@ -392,6 +450,10 @@ executable todo
     , transformers >=0.5 && <0.7
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 executable tutorial
@@ -439,6 +501,10 @@ executable tutorial
     , transformers >=0.5 && <0.7
     , vector >=0.12 && <0.14
     , wreq >=0.5.2 && <0.6
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 test-suite monomer-test

--- a/package.yaml
+++ b/package.yaml
@@ -53,9 +53,9 @@ dependencies:
   - wreq >= 0.5.2 && < 0.6
 
 flags:
-  ignore-examples:
-    default: True
-    manual: False
+  examples:
+    default: False
+    manual: True
 
 library:
   source-dirs: src
@@ -91,8 +91,11 @@ executables:
     main: Main.hs
     source-dirs: examples/todo
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - monomer
     ghc-options:
@@ -102,8 +105,11 @@ executables:
     main: Main.hs
     source-dirs: examples/books
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
@@ -115,8 +121,11 @@ executables:
     main: Main.hs
     source-dirs: examples/ticker
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
@@ -129,8 +138,11 @@ executables:
     main: Main.hs
     source-dirs: examples/generative
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
@@ -141,8 +153,11 @@ executables:
     main: Main.hs
     source-dirs: examples/opengl
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
@@ -153,8 +168,11 @@ executables:
     main: Main.hs
     source-dirs: examples/tutorial
     when:
-      - condition: flag(ignore-examples)
-        buildable: False
+      - condition: flag(examples)
+        then:
+          buildable: True
+        else:
+          buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,11 @@ dependencies:
   - vector >= 0.12 && < 0.14
   - wreq >= 0.5.2 && < 0.6
 
+flags:
+  ignore-examples:
+    default: True
+    manual: False
+
 library:
   source-dirs: src
   include-dirs: cbits
@@ -74,61 +79,87 @@ library:
         extra-libraries: GLEW
 
 executables:
+  dev-test-app:
+    main: Main.hs
+    source-dirs: dev-test-app
+    dependencies:
+      - monomer
+    ghc-options:
+      - -threaded
+
   todo:
     main: Main.hs
     source-dirs: examples/todo
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - monomer
+    ghc-options:
+      - -threaded
 
   books:
     main: Main.hs
     source-dirs: examples/books
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
       - wreq >= 0.5.2 && < 0.6
+    ghc-options:
+      - -threaded
 
   ticker:
     main: Main.hs
     source-dirs: examples/ticker
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - aeson >= 1.4 && < 2.3
       - monomer
       - websockets >= 0.12 && < 0.13
       - wuss >= 1.1 && < 2.3
+    ghc-options:
+      - -threaded
 
   generative:
     main: Main.hs
     source-dirs: examples/generative
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
+    ghc-options:
+      - -threaded
 
   opengl:
     main: Main.hs
     source-dirs: examples/opengl
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
+    ghc-options:
+      - -threaded
 
   tutorial:
     main: Main.hs
     source-dirs: examples/tutorial
-    ghc-options:
-      - -threaded
+    when:
+      - condition: flag(ignore-examples)
+        buildable: False
     dependencies:
       - monomer
       - random >= 1.1 && < 1.3
+    ghc-options:
+      - -threaded
 
 tests:
   monomer-test:


### PR DESCRIPTION
Add `examples` flag to optionally build examples and tutorials. By default the flag is `False`, so examples + tutorials are not built. This is in contrast to the current behavior, where examples and tutorials are always built. In order to build the examples, users need to call:
```shell
stack build --flag monomer:examples
```

Also add a small `dev-test-app` executable. Used to simplify development/testing of the library itself, since it allows to launch it with `ghcid` and have changes to Monomer reloaded automatically. Ideally, a temporary solution.