### PR TITLE
Trigger ResizeWidgets when user defined size requests change

### DIFF
--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -626,7 +626,9 @@ compositeMerge comp state wenv newComp oldComp = newResult where
   reducedResult
     | useNewRoot = toParentResult comp newState wenv styledComp tmpResult
     | otherwise = resultNode oldComp
-  !newResult = handleWidgetIdChange oldComp reducedResult
+  !newResult = reducedResult
+    & handleUserSizeReqChange wenv oldComp
+    & handleWidgetIdChange oldComp
 
 -- | Dispose
 compositeDispose

--- a/src/Monomer/Widgets/Container.hs
+++ b/src/Monomer/Widgets/Container.hs
@@ -662,11 +662,14 @@ mergeWrapper container wenv newNode oldNode = newResult where
     Just (ost, st) -> mergePostHandler wenv mNode oldNode ost st mResult
     Nothing -> mResult
 
-  tmpResult
-    | isResizeAnyResult (Just postRes) = postRes
-        & L.node .~ updateSizeReq wenv (postRes ^. L.node)
-    | otherwise = postRes
-  newResult = handleWidgetIdChange oldNode tmpResult
+  tmpResult = postRes
+    & handleUserSizeReqChange wenv oldNode
+    & handleWidgetIdChange oldNode
+
+  newResult
+    | isResizeAnyResult (Just tmpResult) = tmpResult
+        & L.node .~ updateSizeReq wenv (tmpResult ^. L.node)
+    | otherwise = tmpResult
 
 mergeParent
   :: WidgetModel a

--- a/src/Monomer/Widgets/Single.hs
+++ b/src/Monomer/Widgets/Single.hs
@@ -368,7 +368,7 @@ mergeWrapper single wenv newNode oldNode = newResult where
   nodeHandler wenv styledNode = case useState oldState of
     Just state -> mergeHandler wenv styledNode oldNode state
     _ -> resultNode styledNode
-  tmpResult = runNodeHandler single wenv newNode oldInfo nodeHandler
+  tmpResult = runNodeHandler single wenv newNode oldNode nodeHandler
   newResult = handleWidgetIdChange oldNode tmpResult
 
 runNodeHandler
@@ -376,10 +376,11 @@ runNodeHandler
   => Single s e a
   -> WidgetEnv s e
   -> WidgetNode s e
-  -> WidgetNodeInfo
+  -> WidgetNode s e
   -> (WidgetEnv s e -> WidgetNode s e -> WidgetResult s e)
   -> WidgetResult s e
-runNodeHandler single wenv newNode oldInfo nodeHandler = newResult where
+runNodeHandler single wenv newNode oldNode nodeHandler = newResult where
+  oldInfo = oldNode ^. L.info
   getBaseStyle = singleGetBaseStyle single
   tempNode = newNode
     & L.info . L.widgetId .~ oldInfo ^. L.widgetId
@@ -389,6 +390,9 @@ runNodeHandler single wenv newNode oldInfo nodeHandler = newResult where
   styledNode = initNodeStyle getBaseStyle wenv tempNode
 
   tmpResult = nodeHandler wenv styledNode
+    & handleUserSizeReqChange wenv oldNode
+    & handleWidgetIdChange oldNode
+
   newResult
     | isResizeAnyResult (Just tmpResult) = tmpResult
         & L.node .~ updateSizeReq wenv (tmpResult ^. L.node)


### PR DESCRIPTION
Although requests for resizing originated in widgets were already handled, user defined size requests (set through `styleBasic` and related) were not generating a `ResizeWidgets` when the values changed.

Discussed here: https://github.com/fjvallarino/monomer/issues/228
