### PR TITLE
Avoid infinite resize loop in multiline label

### DIFF
--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -352,7 +352,7 @@ mainLoop window fontManager config loopArgs = do
   renderMethod <- use L.renderMethod
 
   let actionEvt = any isActionEvent eventsPayload
-  let renderResize = windowResized && isLeft renderMethod
+  let renderResize = windowResized && (isLinux wenv || isLeft renderMethod)
   let windowRenderEvt = renderResize || any isWindowRenderEvent eventsPayload
   let renderNeeded = windowRenderEvt || actionEvt || renderCurrentReq
 


### PR DESCRIPTION
Multiline labels require resizing in two steps, since the label height depends on the assigned width. As described in the associated issue, in some cases having a multiline label resized could cause an infinite loop of resize requests.

Discussed here: https://github.com/fjvallarino/monomer/issues/225