### PR TITLE
Avoid weird macOS 'command encoder is already encoding to this command buffer' error when resizing window

### DIFF
--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -352,7 +352,7 @@ mainLoop window fontManager config loopArgs = do
   renderMethod <- use L.renderMethod
 
   let actionEvt = any isActionEvent eventsPayload
-  let renderResize = windowResized && isLeft renderMethod
+  let renderResize = windowResized && (isLinux wenv || isLeft renderMethod)
   let windowRenderEvt = renderResize || any isWindowRenderEvent eventsPayload
   let renderNeeded = windowRenderEvt || actionEvt || renderCurrentReq
 


### PR DESCRIPTION
Resizing the window on M1 macOS caused the application to crash in some cases, and an _"A command encoder is already encoding to this command buffer"_ message was displayed in the console. Avoiding to redraw when resize has finished seems to solve the problem (since continuous resizing redraws the screen, this last render step was not really needed).

Similar issues:

  - https://github.com/libgdx/libgdx/issues/6987
  - https://github.com/opentk/opentk/issues/1457
