### PR TITLE
Modify tests for selectList and dropdown

### DIFF
--- a/test/unit/Monomer/Widgets/Containers/DropdownSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/DropdownSpec.hs
@@ -76,6 +76,9 @@ handleEvent = describe "handleEvent" $ do
   it "should not update the model if not clicked" $
     model [evtClick (Point 3000 3000)] ^. selectedItem `shouldBe` testItem0
 
+  it "should not update the model if clicked outside the list" $
+    model [evtClick mainP, evtClick (Point 300 500)] ^. selectedItem `shouldBe` testItem0
+
   it "should update the model when clicked" $ do
     let itemP = Point 50 90
     model [evtClick mainP, evtClick itemP] ^. selectedItem `shouldBe` testItem3

--- a/test/unit/Monomer/Widgets/Containers/SelectListSpec.hs
+++ b/test/unit/Monomer/Widgets/Containers/SelectListSpec.hs
@@ -72,8 +72,8 @@ spec = describe "SelectList" $ do
 
 handleEvent :: Spec
 handleEvent = describe "handleEvent" $ do
-  it "should not update the model if not clicked" $
-    clickModel (Point 3000 3000) ^. selectedItem `shouldBe` testItem0
+  it "should not update the model if clicked outside the list" $
+    clickModel (Point 300 500) ^. selectedItem `shouldBe` testItem0
 
   it "should update the model when clicked" $
     clickModel (Point 100 70) ^. selectedItem `shouldBe` testItem3


### PR DESCRIPTION
Hi @fjvallarino!
In #227 you said you weren't able to generate a failing unit test that your PR (#230) fixes. I added a test for dropdown and modified existing test for selectList. They both fail before your commit and pass after.