### PR TITLE
Export dialD_

### DIFF
--- a/src/Monomer/Widgets/Singles/Dial.hs
+++ b/src/Monomer/Widgets/Singles/Dial.hs
@@ -33,7 +33,8 @@ module Monomer.Widgets.Singles.Dial (
   dial,
   dial_,
   dialV,
-  dialV_
+  dialV_,
+  dialD_
 ) where
 
 import Control.Applicative ((<|>))


### PR DESCRIPTION
`sliderD_` is exported in [Slider.hs](https://github.com/fjvallarino/monomer/blob/main/src/Monomer/Widgets/Singles/Slider.hs), but `dialD_` is not exported in [Dial.hs](https://github.com/fjvallarino/monomer/blob/main/src/Monomer/Widgets/Singles/Dial.hs). It is similar in objective to Slider, so I believe that `dialD_` should be exported.