### PR TITLE
Fix link to the article: "Haskell Antipattern: Existential Typeclass"

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -132,7 +132,7 @@ Because of the first reason, there were not advantages by using typeclasses
 compared to using records. This situation of wrapping a typeclass in an
 existential is referred to as _"Existential Typeclass Anti Pattern"_. For
 example,
-[here](https://lukepalmer.wordpress.com/2010/01/24/haskell-antipattern-existential-typeclass).
+[here](https://web.archive.org/web/20201109041924/http://lukepalmer.wordpress.com/2010/01/24/haskell-antipattern-existential-typeclass/).
 
 ## Why do you use lawless typeclasses for combinators?
 


### PR DESCRIPTION
[Design decisions](https://github.com/fjvallarino/monomer/blob/main/docs/design-decisions.md#why-records-of-functions-instead-of-typeclasses) have [this link](https://lukepalmer.wordpress.com/2010/01/24/haskell-antipattern-existential-typeclass) to the article: "Haskell Antipattern: Existential Typeclass". Currently the site just shows "Private Site". But there is [saved page](https://web.archive.org/web/20201109041924/http://lukepalmer.wordpress.com/2010/01/24/haskell-antipattern-existential-typeclass/) on the Wayback Machine, so I replaced the link with the archived version.