### PR TITLE
Minor clarification in WidgetEnv's widgetKeyMap

### DIFF
--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -329,10 +329,12 @@ data WidgetEnv s e = WidgetEnv {
   _weWidgetShared :: MVar (Map Text WidgetShared),
   {-|
   The active map of WidgetKey -> WidgetNode, if any. This map is restricted to
-  to the parent "Monomer.Widgets.Composite". Do not use this map directly, rely
-  instead on the 'Monomer.Core.Util.widgetIdFromKey',
-  'Monomer.Core.Util.nodeInfoFromKey' and 'Monomer.Core.Util.nodeInfoFromPath'
-  utility functions.
+  to the parent "Monomer.Widgets.Composite".
+
+  It is recommended to not use this map directly, since `WidgetNodeInfo` may be
+  stale (path and widgetId are always valid). Because of this it is safer to use
+  the 'Monomer.Core.Util.widgetIdFromKey', 'Monomer.Core.Util.nodeInfoFromKey'
+  and 'Monomer.Core.Util.nodeInfoFromPath' utility functions.
   -}
   _weWidgetKeyMap :: WidgetKeyMap s e,
   -- | The currently hovered path, if any.


### PR DESCRIPTION
Since Container relies on `widgetKeyMap` during merge, removing it or restricting it to `(path, widgetId)` is not possible without causing performance issues (the `widget` instance will need to be looked up by path instead of key).

For this reason I just added a clearer note.