### PR TITLE
Fix type error in examples

### DIFF
--- a/examples/books/Main.hs
+++ b/examples/books/Main.hs
@@ -140,7 +140,7 @@ handleEvent
   -> WidgetNode BooksModel BooksEvt
   -> BooksModel
   -> BooksEvt
-  -> [EventResponse BooksModel BooksEvt BooksModel ()]
+  -> [EventResponse BooksModel BooksEvt BooksModel BooksEvt]
 handleEvent sess wenv node model evt = case evt of
   BooksInit -> [SetFocusOnKey "query"]
   BooksSearch -> [

--- a/examples/generative/Main.hs
+++ b/examples/generative/Main.hs
@@ -101,7 +101,7 @@ handleEvent
   -> GenerativeNode
   -> GenerativeModel
   -> GenerativeEvt
-  -> [EventResponse GenerativeModel GenerativeEvt GenerativeModel GenerativeEvt]
+  -> [EventResponse GenerativeModel GenerativeEvt GenerativeModel ()]
 handleEvent wenv node model evt = case evt of
   GenerativeInit -> [SetFocusOnKey "activeType"]
 

--- a/examples/generative/Main.hs
+++ b/examples/generative/Main.hs
@@ -101,7 +101,7 @@ handleEvent
   -> GenerativeNode
   -> GenerativeModel
   -> GenerativeEvt
-  -> [EventResponse GenerativeModel GenerativeEvt GenerativeModel ()]
+  -> [EventResponse GenerativeModel GenerativeEvt GenerativeModel GenerativeEvt]
 handleEvent wenv node model evt = case evt of
   GenerativeInit -> [SetFocusOnKey "activeType"]
 

--- a/examples/ticker/Main.hs
+++ b/examples/ticker/Main.hs
@@ -123,7 +123,7 @@ handleEvent
   -> TickerNode
   -> TickerModel
   -> TickerEvt
-  -> [EventResponse TickerModel TickerEvt TickerModel ()]
+  -> [EventResponse TickerModel TickerEvt TickerModel TickerEvt]
 handleEvent env wenv node model evt = case evt of
   TickerInit -> [
     Model $ model

--- a/examples/todo/Main.hs
+++ b/examples/todo/Main.hs
@@ -168,7 +168,7 @@ handleEvent
   -> TodoNode
   -> TodoModel
   -> TodoEvt
-  -> [EventResponse TodoModel TodoEvt TodoModel ()]
+  -> [EventResponse TodoModel TodoEvt TodoModel TodoEvt]
 handleEvent wenv node model evt = case evt of
   TodoInit -> [SetFocusOnKey "todoNew"]
 

--- a/nix/monomer.nix
+++ b/nix/monomer.nix
@@ -23,7 +23,7 @@ with super.haskellPackages.extend (self: super:
   }); rec {
     libraries = recurseIntoAttrs {
       monomer = addExtraLibrary
-        (overrideCabal (callCabal2nix "monomer" ../. { }) (o: {
+        (overrideCabal (callCabal2nixWithOptions "monomer" ../. "-fexamples" { }) (o: {
           version = "${o.version}.${version}";
           doCheck = true;
           checkPhase = ''


### PR DESCRIPTION
When https://github.com/fjvallarino/monomer/pull/239 was merged, an update to the examples should have been included.

This PR fixes the type errors and updates the CI process to build the examples; this will help to detect this kind of omission in the future.

Discussed here: https://github.com/fjvallarino/monomer/issues/262
