### PR TITLE
Fix flake.nix definition to work with more recent nixpkgs snapshots

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1629366148,
-        "narHash": "sha256-CIfmrcptxXiCVH9UCKRq44IHcSW8WQ8yQQPTavOpUF8=",
+        "lastModified": 1682554371,
+        "narHash": "sha256-UYm0a60XOmBDBQqgySDRN8LUV5xWZn26OzjTCeVrYDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5c2212cdfceb727b072223e460eb7dcefbc4062",
+        "rev": "dc9fe27b825a4196fe81a583eb3a174da847660e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,5 +29,13 @@
         };
         defaultPackage = packages.monomer;
         defaultApp = apps.tutorial;
+        devShell = haskellPackages.shellFor {
+          packages = p: [ packages.monomer ];
+          withHoogle = true;
+          buildInputs = with haskellPackages; [
+            haskell-language-server
+            cabal-install
+          ];
+        };
       });
 }

--- a/nix/monomer.nix
+++ b/nix/monomer.nix
@@ -16,7 +16,7 @@ with super.haskellPackages.extend (self: super:
       rev = "283516a337c4d3606555728df0a39294e78a7cdf";
       sha256 = "1vggli76ijqmx633yix4yg5dv58a14p8561jnprjc061sjngphzv";
     }) "-fexamples -fstb_truetype" {
-      inherit GLEW glew libGL libGLU;
+      inherit glew libGL libGLU;
       inherit (xorg) libX11;
     });
     GLEW = glew;

--- a/nix/qemu.nix
+++ b/nix/qemu.nix
@@ -92,14 +92,14 @@ in rec {
             };
           };
 
-          virtualisation = {
-            graphics = true;
-            cores = 4;
-            qemu.networkingOptions = [
-              "-device virtio-net-pci,netdev=user.0"
-              "-netdev type=user,id=user.0\${QEMU_NET_OPTS:+,$QEMU_NET_OPTS}"
-            ];
-          };
+          # virtualisation = {
+          #   graphics = true;
+          #   cores = 4;
+          #   qemu.networkingOptions = [
+          #     "-device virtio-net-pci,netdev=user.0"
+          #     "-netdev type=user,id=user.0\${QEMU_NET_OPTS:+,$QEMU_NET_OPTS}"
+          #   ];
+          # };
         };
     }).vm;
   };


### PR DESCRIPTION
Hello, thanks for all your work on `Monomer`. It has been fun to read this project. 

I modified the flake.nix definition so it is easier to work on a recent nixpkgs snapshot.

# Changes

- The `virtualisation` options don't go by that name anymore. I commented those lines so `nix flake show` would work. I was not able to make it work.
-  Added a `devShell` section, so running the haskell language server is easier.
- I removed a superflous `GLEW` dependency on `nanovg`.
- Updated the flake.lock file.

# Tests

I am using this on my local environment. So far I can run `cabal v2-build` and use the language server with emacs.