### PR TITLE
Remove redundant imports and fix typos

### DIFF
--- a/dev-test-app/Main.hs
+++ b/dev-test-app/Main.hs
@@ -4,12 +4,8 @@
 module Main where
 
 import Control.Lens
-import Data.Maybe
-import Data.Text (Text)
 import Monomer
 import TextShow
-
-import qualified Monomer.Lens as L
 
 newtype AppModel = AppModel {
   _clickCount :: Int

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/src/Monomer/Common/Lens.hs
+++ b/src/Monomer/Common/Lens.hs
@@ -14,7 +14,7 @@ Lenses for the Common types.
 
 module Monomer.Common.Lens where
 
-import Control.Lens.TH (abbreviatedFields, makeLensesWith, makePrisms)
+import Control.Lens.TH (abbreviatedFields, makeLensesWith)
 
 import Monomer.Common.BasicTypes
 

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -43,7 +43,6 @@ import Data.Maybe
 import Monomer.Common
 import Monomer.Core.StyleTypes
 import Monomer.Core.StyleUtil
-import Monomer.Core.Util
 import Monomer.Helper
 
 import qualified Monomer.Core.Lens as L

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -11,7 +11,7 @@ Helper functions creating, validating and merging size requirements.
 {-# LANGUAGE Strict #-}
 
 module Monomer.Core.SizeReq (
-  SizeReqUpdater(..),
+  SizeReqUpdater,
   clearExtra,
   clearExtraW,
   clearExtraH,

--- a/src/Monomer/Core/SizeReq.hs
+++ b/src/Monomer/Core/SizeReq.hs
@@ -41,7 +41,7 @@ import Data.Default
 import Data.Maybe
 
 import Monomer.Common
-import Monomer.Core.StyleTypes
+import Monomer.Core.Style
 import Monomer.Core.StyleUtil
 import Monomer.Helper
 

--- a/src/Monomer/Core/StyleTypes.hs
+++ b/src/Monomer/Core/StyleTypes.hs
@@ -19,7 +19,6 @@ import GHC.Generics
 
 import Monomer.Common
 import Monomer.Graphics.Types
-import Monomer.Graphics.Util
 
 {-|
 Represents a size requirement for a specific axis. Mainly used by stack and box,

--- a/src/Monomer/Core/ThemeTypes.hs
+++ b/src/Monomer/Core/ThemeTypes.hs
@@ -22,7 +22,6 @@ import qualified Data.Map.Strict as M
 import Monomer.Core.StyleTypes
 import Monomer.Graphics.ColorTable
 import Monomer.Graphics.Types
-import Monomer.Graphics.Util
 
 -- | Theme configuration for each state, plus clear/base color.
 data Theme = Theme {

--- a/src/Monomer/Core/Themes/BaseTheme.hs
+++ b/src/Monomer/Core/Themes/BaseTheme.hs
@@ -16,7 +16,7 @@ module Monomer.Core.Themes.BaseTheme (
   baseTheme
 ) where
 
-import Control.Lens ((&), (^.), (.~), (?~), non)
+import Control.Lens ((&), (.~), (?~), non)
 import Data.Default
 
 import Monomer.Core.Combinators

--- a/src/Monomer/Core/Themes/SampleThemes.hs
+++ b/src/Monomer/Core/Themes/SampleThemes.hs
@@ -15,7 +15,7 @@ module Monomer.Core.Themes.SampleThemes (
   darkThemeColors
 ) where
 
-import Control.Lens ((&), (^.), (.~), (?~), non)
+import Control.Lens ((&), (.~))
 
 import Monomer.Core.ThemeTypes
 import Monomer.Core.Themes.BaseTheme

--- a/src/Monomer/Core/Util.hs
+++ b/src/Monomer/Core/Util.hs
@@ -13,18 +13,15 @@ Helper functions for Core types.
 
 module Monomer.Core.Util where
 
-import Control.Lens ((&), (^.), (^?), (.~), (?~), _Just)
+import Control.Lens ((^.), (^?), _Just)
 import Data.Maybe
-import Data.Text (Text)
 import Data.Typeable (cast)
 import Data.Sequence (Seq(..))
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
-import qualified Data.Text as T
 
 import Monomer.Common
-import Monomer.Core.Style
 import Monomer.Core.WidgetTypes
 import Monomer.Helper
 

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -182,8 +182,7 @@ data WidgetRequest s e
   | StopTextInput
   -- | Sets a widget as the base target of future events. This is used by the
   --   dropdown component to handle list events; this list, acting as an
-  --   overlay, is displayed on top of all other widgets. Tooltip uses it too.
-  --   every other widget).
+  --   overlay, is displayed on top of all other widgets. Popup uses it too.
   | SetOverlay WidgetId Path
   -- | Removes the existing overlay.
   | ResetOverlay WidgetId

--- a/src/Monomer/Core/WidgetTypes.hs
+++ b/src/Monomer/Core/WidgetTypes.hs
@@ -12,7 +12,7 @@ Basic types and definitions for Widgets.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# Language GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Strict #-}
 

--- a/src/Monomer/Event/Core.hs
+++ b/src/Monomer/Event/Core.hs
@@ -16,14 +16,12 @@ module Monomer.Event.Core (
 ) where
 
 import Control.Applicative ((<|>))
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 
-import qualified Data.Map.Strict as M
 import qualified SDL
 
 import Monomer.Common
-import Monomer.Event.Keyboard
 import Monomer.Event.Types
 
 {-|

--- a/src/Monomer/Event/Lens.hs
+++ b/src/Monomer/Event/Lens.hs
@@ -16,7 +16,6 @@ module Monomer.Event.Lens where
 
 import Control.Lens.TH (abbreviatedFields, makeLensesWith)
 
-import Monomer.Common.Lens
 import Monomer.Event.Types
 
 makeLensesWith abbreviatedFields ''InputStatus

--- a/src/Monomer/Event/Util.hs
+++ b/src/Monomer/Event/Util.hs
@@ -29,12 +29,6 @@ module Monomer.Event.Util (
   checkKeyboard
 ) where
 
-import Data.Maybe (fromMaybe)
-
-import qualified Data.Map as M
-
-import Monomer.Event.Core
-import Monomer.Event.Keyboard
 import Monomer.Event.Types
 
 -- | Checks if Windows/Cmd key is pressed.

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -19,7 +19,6 @@ import Control.Monad (foldM, when)
 import Control.Lens ((^.))
 
 import Data.Default
-import Data.Sequence (Seq)
 import Data.Text (Text)
 import System.IO.Unsafe
 

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -16,27 +16,22 @@ Renderer based on the nanovg library.
 
 module Monomer.Graphics.NanoVGRenderer (makeRenderer) where
 
-import Control.Lens ((&), (^.), (.~))
-import Control.Monad (foldM, forM_, unless, when)
+import Control.Lens ((^.))
+import Control.Monad (foldM, forM_, when)
 import Data.Default
 import Data.Functor ((<&>))
 import Data.IORef
-import Data.List (foldl')
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
+import Data.Sequence (Seq(..), (|>))
 import Data.Set (Set(..))
 import Data.Text (Text)
-import Data.Text.Foreign (withCStringLen)
 import Foreign.C.Types (CFloat)
-import Foreign.Ptr
-import System.IO.Unsafe
 
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import qualified Data.Vector as V
 import qualified NanoVG as VG
 import qualified NanoVG.Internal.Image as VGI
 

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -23,7 +23,7 @@ import Data.Functor ((<&>))
 import Data.IORef
 import Data.Maybe
 import Data.Sequence (Seq(..), (|>))
-import Data.Set (Set(..))
+import Data.Set (Set)
 import Data.Text (Text)
 import Foreign.C.Types (CFloat)
 

--- a/src/Monomer/Graphics/Text.hs
+++ b/src/Monomer/Graphics/Text.hs
@@ -29,7 +29,7 @@ import Control.Lens ((&), (^.), (^?), (+~), ix, non)
 import Data.Default
 import Data.List (foldl')
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
+import Data.Sequence (Seq(..), (<|))
 import Data.Text (Text)
 
 import qualified Data.Sequence as Seq

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -24,7 +24,6 @@ import Control.Concurrent
 import Control.Concurrent.STM.TChan (TChan, newTChanIO, readTChan, writeTChan)
 import Control.Exception
 import Control.Lens ((&), (^.), (.=), (.~), _2, use)
-import Control.Monad (unless, void, when)
 import Control.Monad.Extra
 import Control.Monad.State
 import Control.Monad.STM (atomically)
@@ -32,7 +31,6 @@ import Data.Default
 import Data.Either (isLeft)
 import Data.Maybe (fromMaybe, fromJust, isJust)
 import Data.Map (Map)
-import Data.List (foldl')
 import Data.Text (Text)
 import Data.Time
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -14,9 +14,9 @@ Core glue for running an application.
 {-# LANGUAGE Strict #-}
 
 module Monomer.Main.Core (
-  AppEventResponse(..),
-  AppEventHandler(..),
-  AppUIBuilder(..),
+  AppEventResponse,
+  AppEventHandler,
+  AppUIBuilder,
   startApp
 ) where
 

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -66,7 +66,7 @@ for unit testing purposes.
 type HandlerStep s e = (WidgetEnv s e, WidgetNode s e, Seq (WidgetRequest s e))
 
 {-|
-Processes a list of SystemEvents dispatching each of the to the corresponding
+Processes a list of SystemEvents dispatching each to the corresponding
 widget based on the current root. At each step the root may change, new events
 may be generated (which will be processed interleaved with the list of events)
 and this is handled before returning the latest "HandlerStep".
@@ -76,7 +76,7 @@ handleSystemEvents
   => WidgetEnv s e       -- ^ The initial widget environment.
   -> WidgetNode s e      -- ^ The initial widget root.
   -> [SystemEvent]       -- ^ The starting list of events.
-  -> m (HandlerStep s e) -- ^ The resulting "HandlerStep."
+  -> m (HandlerStep s e) -- ^ The resulting "HandlerStep".
 handleSystemEvents wenv widgetRoot baseEvents = nextStep where
   mainBtn = wenv ^. L.mainButton
   reduceEvt curStep evt = do

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -27,18 +27,18 @@ module Monomer.Main.Handlers (
 
 import Control.Concurrent.Async (async)
 import Control.Lens
-  ((&), (^.), (^?), (.~), (?~), (%~), (.=), (?=), (%=), (%%~), _Just, _1, _2, ix, at, use)
+  ((&), (^.), (.~), (?~), (%~), (.=), (?=), (%=), (%%~), _Just, _1, at, use)
 import Control.Monad.STM (atomically)
 import Control.Concurrent.STM.TChan (TChan, newTChanIO, readTChan, writeTChan)
 import Control.Applicative ((<|>))
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Default
-import Data.Foldable (fold, toList)
+import Data.Foldable (toList)
 import Data.Maybe
 import Data.Sequence (Seq(..), (|>))
 import Data.Text (Text)
-import Data.Typeable (Typeable, typeOf)
+import Data.Typeable (Typeable)
 import SDL (($=))
 
 import qualified Data.Map as Map

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -23,12 +23,10 @@ module Monomer.Main.Platform (
 ) where
 
 import Control.Exception (finally)
-import Control.Monad (void)
 import Control.Monad.Extra (whenJust)
 import Control.Monad.State
 import Data.Maybe
 import Data.Text (Text)
-import Data.Word
 import Foreign (alloca, peek)
 import Foreign.C (peekCString, withCString)
 import Foreign.C.Types

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -50,7 +50,7 @@ import Monomer.Main.Types
 foreign import ccall unsafe "initGlew" glewInit :: IO CInt
 foreign import ccall unsafe "initDpiAwareness" initDpiAwareness :: IO CInt
 
--- | Default window size if not is specified.
+-- | Default window size if not specified.
 defaultWindowSize :: (Int, Int)
 defaultWindowSize = (800, 600)
 

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -30,7 +30,6 @@ import Data.Typeable (Typeable)
 import Data.Sequence (Seq)
 import GHC.Generics
 
-import qualified Data.Map as M
 import qualified SDL
 import qualified SDL.Raw.Types as SDLR
 

--- a/src/Monomer/Main/UserUtil.hs
+++ b/src/Monomer/Main/UserUtil.hs
@@ -13,17 +13,14 @@ change and clipboard requests.
 
 module Monomer.Main.UserUtil where
 
-import Control.Applicative ((<|>))
 import Control.Lens
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 
 import Monomer.Widgets.Composite
 import Monomer.Widgets.Singles.Spacer
 
 import qualified Monomer.Core.Lens as L
-import qualified Monomer.Main.Lens as L
 
 {-# DEPRECATED setFocusOnKey "Use SetFocusOnKey instead (wenv argument should be removed)." #-}
 {-|

--- a/src/Monomer/Main/Util.hs
+++ b/src/Monomer/Main/Util.hs
@@ -14,13 +14,9 @@ Helper functions for the Main module.
 
 module Monomer.Main.Util where
 
-import Control.Applicative ((<|>))
 import Control.Concurrent.STM.TChan
-import Control.Lens ((&), (^.), (.=), (%=), ix, at, non, use, _1)
-import Control.Monad.Extra
-import Control.Monad.State
+import Control.Lens ((^.), (.=), at, non, use)
 import Data.Default
-import Data.Maybe
 
 import qualified Data.Sequence as Seq
 import qualified Data.Map as Map
@@ -29,9 +25,7 @@ import qualified SDL
 import Monomer.Core
 import Monomer.Event
 import Monomer.Helper (headMay)
-import Monomer.Main.Platform
 import Monomer.Main.Types
-import Monomer.Widgets.Util.Widget
 
 import qualified Monomer.Core.Lens as L
 import qualified Monomer.Main.Lens as L

--- a/src/Monomer/Main/WidgetTask.hs
+++ b/src/Monomer/Main/WidgetTask.hs
@@ -17,7 +17,7 @@ module Monomer.Main.WidgetTask (handleWidgetTasks) where
 import Control.Concurrent.Async (poll)
 import Control.Concurrent.STM.TChan (tryReadTChan)
 import Control.Exception.Base
-import Control.Lens ((&), (^.), (.=), use)
+import Control.Lens ((^.), (.=), use)
 import Control.Monad.Extra
 import Control.Monad.IO.Class
 import Control.Monad.STM (atomically)

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -30,11 +30,10 @@ module Monomer.Widgets.Animation.Fade (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~), (%~), at)
+import Control.Lens ((&), (^.), (.~))
 import Control.Monad (when)
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 import Data.Typeable (cast)
 import GHC.Generics
 

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -33,7 +33,7 @@ module Monomer.Widgets.Animation.Slide (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~), (%~), at)
+import Control.Lens ((&), (^.), (.~))
 import Control.Monad (when)
 import Data.Default
 import Data.Maybe

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -156,7 +156,7 @@ animSlideOut
   -> WidgetNode s e  -- ^ The created animation container.
 animSlideOut managed = animSlideOut_ def managed
 
--- | Animates a widget to the the provided direction from visible to not
+-- | Animates a widget to the provided direction from visible to not
 --   visible (defaults to left). Accepts config.
 animSlideOut_
   :: WidgetEvent e

--- a/src/Monomer/Widgets/Composite.hs
+++ b/src/Monomer/Widgets/Composite.hs
@@ -66,14 +66,13 @@ module Monomer.Widgets.Composite (
 import Debug.Trace
 
 import Control.Applicative ((<|>))
-import Control.Exception (AssertionFailed(..), throw)
-import Control.Lens (ALens', (&), (^.), (^?), (.~), (%~), (<>~), at, ix, non)
+import Control.Lens (ALens', (&), (^.), (.~), (%~), (<>~))
 import Control.Monad (when)
 import Data.Default
 import Data.List (foldl')
 import Data.Map.Strict (Map)
 import Data.Maybe
-import Data.Sequence (Seq(..), (|>), (<|), fromList)
+import Data.Sequence (Seq(..), (|>), (<|))
 import Data.Typeable (Typeable, cast, typeOf)
 
 import qualified Data.Map.Strict as M

--- a/src/Monomer/Widgets/Container.hs
+++ b/src/Monomer/Widgets/Container.hs
@@ -49,11 +49,10 @@ module Monomer.Widgets.Container (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Exception (AssertionFailed(..), throw)
-import Control.Lens ((&), (^.), (^?), (.~), (%~), (<>~), _Just)
+import Control.Lens ((&), (^.), (.~), (%~), (<>~))
 import Control.Monad
 import Data.Default
-import Data.Foldable (fold, foldl')
+import Data.Foldable (foldl')
 import Data.Maybe
 import Data.Map.Strict (Map)
 import Data.Typeable (Typeable)

--- a/src/Monomer/Widgets/Containers/Alert.hs
+++ b/src/Monomer/Widgets/Containers/Alert.hs
@@ -40,18 +40,15 @@ module Monomer.Widgets.Containers.Alert (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (.~), (%~))
+import Control.Lens ((&), (.~))
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)
-
-import qualified Data.Sequence as Seq
 
 import Monomer.Core
 import Monomer.Core.Combinators
 
 import Monomer.Widgets.Composite
-import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Box
 import Monomer.Widgets.Containers.BoxShadow
 import Monomer.Widgets.Containers.Keystroke

--- a/src/Monomer/Widgets/Containers/Base/LabeledItem.hs
+++ b/src/Monomer/Widgets/Containers/Base/LabeledItem.hs
@@ -21,10 +21,8 @@ module Monomer.Widgets.Containers.Base.LabeledItem (
   labeledItem
 ) where
 
-import Control.Applicative ((<|>))
 import Data.Default
-import Control.Lens ((&), (^.), (^?), (^?!), (.~), (<>~), ix)
-import Data.Maybe
+import Control.Lens ((&), (^.), (^?!), (.~), (<>~), ix)
 import Data.Sequence ((|>))
 import Data.Text (Text)
 
@@ -36,7 +34,6 @@ import Monomer.Core.Combinators as Cmb
 import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Stack
 import Monomer.Widgets.Singles.Label
-import Monomer.Widgets.Singles.Spacer
 
 import qualified Monomer.Lens as L
 

--- a/src/Monomer/Widgets/Containers/Draggable.hs
+++ b/src/Monomer/Widgets/Containers/Draggable.hs
@@ -39,7 +39,7 @@ module Monomer.Widgets.Containers.Draggable (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (^?!), (.~), _Just, _1, _2, at, ix)
+import Control.Lens ((&), (^.), (^?!), (.~), _Just, _2)
 import Control.Monad (forM_, when)
 import Data.Default
 import Data.Maybe

--- a/src/Monomer/Widgets/Containers/DropTarget.hs
+++ b/src/Monomer/Widgets/Containers/DropTarget.hs
@@ -36,7 +36,6 @@ module Monomer.Widgets.Containers.DropTarget (
 ) where
 
 import Control.Lens ((&), (^.), (.~))
-import Control.Monad (when)
 import Data.Default
 import Data.Maybe
 import Data.Typeable (cast)

--- a/src/Monomer/Widgets/Containers/Dropdown.hs
+++ b/src/Monomer/Widgets/Containers/Dropdown.hs
@@ -51,14 +51,13 @@ module Monomer.Widgets.Containers.Dropdown (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (^?), (^?!), (.~), (%~), (<>~), _Just, ix, non)
+import Control.Lens (ALens', (&), (^.), (^?!), (.~), (%~), (<>~), ix, non)
 import Control.Monad
 import Data.Default
 import Data.List (foldl')
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
-import Data.Text (Text)
-import Data.Typeable (Typeable, Proxy, cast, typeRep)
+import Data.Sequence (Seq(..), (|>))
+import Data.Typeable (Proxy, cast, typeRep)
 import GHC.Generics
 import TextShow
 
@@ -67,7 +66,6 @@ import qualified Data.Sequence as Seq
 import Monomer.Helper
 import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.SelectList
-import Monomer.Widgets.Singles.Label
 
 import qualified Monomer.Lens as L
 

--- a/src/Monomer/Widgets/Containers/Keystroke.hs
+++ b/src/Monomer/Widgets/Containers/Keystroke.hs
@@ -79,10 +79,10 @@ module Monomer.Widgets.Containers.Keystroke (
 import Debug.Trace (traceShow)
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (^..), (.~), (%~), _1, at, folded)
+import Control.Lens ((&), (^.), (^..), (.~), (%~), _1, folded)
 import Control.Lens.TH (abbreviatedFields, makeLensesWith)
 import Data.Bifunctor (first)
-import Data.Char (chr, isAscii, isPrint, ord)
+import Data.Char (isAscii, isPrint, ord)
 import Data.Default
 import Data.List (foldl')
 import Data.Set (Set)

--- a/src/Monomer/Widgets/Containers/Scroll.hs
+++ b/src/Monomer/Widgets/Containers/Scroll.hs
@@ -52,7 +52,7 @@ module Monomer.Widgets.Containers.Scroll (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (.~), (^?), (^?!), (<>~), (%~), _Just, cloneLens, ix)
+import Control.Lens (ALens', (&), (^.), (.~), (^?), (^?!), (<>~), _Just, cloneLens, ix)
 import Control.Monad
 import Data.Default
 import Data.Maybe

--- a/src/Monomer/Widgets/Containers/SelectList.hs
+++ b/src/Monomer/Widgets/Containers/SelectList.hs
@@ -46,25 +46,20 @@ module Monomer.Widgets.Containers.SelectList (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (^?), (^?!), (.~), (%~), (?~), (<>~), at, ix, non, _Just)
-import Control.Monad (when)
+import Control.Lens (ALens', (&), (^.), (.~), (%~), at, ix)
 import Data.Default
 import Data.List (foldl')
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
-import Data.Text (Text)
+import Data.Sequence (Seq(..), (|>))
 import Data.Typeable (Typeable, Proxy, cast, typeRep)
 import TextShow
 
-import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
 
 import Monomer.Widgets.Container
 import Monomer.Widgets.Containers.Box
 import Monomer.Widgets.Containers.Scroll
 import Monomer.Widgets.Containers.Stack
-import Monomer.Widgets.Singles.Label
-import Monomer.Widgets.Singles.Spacer
 
 import qualified Monomer.Lens as L
 

--- a/src/Monomer/Widgets/Containers/Split.hs
+++ b/src/Monomer/Widgets/Containers/Split.hs
@@ -45,7 +45,6 @@ import Control.Applicative ((<|>))
 import Control.Lens (ALens', (&), (^.), (.~), (<>~))
 import Data.Default
 import Data.Maybe
-import Data.Tuple (swap)
 import GHC.Generics
 
 import qualified Data.Sequence as Seq

--- a/src/Monomer/Widgets/Containers/Stack.hs
+++ b/src/Monomer/Widgets/Containers/Stack.hs
@@ -51,12 +51,11 @@ module Monomer.Widgets.Containers.Stack (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~), (%~))
+import Control.Lens ((&), (.~), (%~))
 import Data.Default
-import Data.Foldable (toList)
 import Data.List (foldl')
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
+import Data.Sequence (Seq(..), (|>))
 
 import qualified Data.Sequence as Seq
 

--- a/src/Monomer/Widgets/Containers/ThemeSwitch.hs
+++ b/src/Monomer/Widgets/Containers/ThemeSwitch.hs
@@ -40,10 +40,8 @@ module Monomer.Widgets.Containers.ThemeSwitch (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Monad (when)
-import Control.Lens ((&), (^.), (.~), (%~), at)
+import Control.Lens ((&), (^.), (.~))
 import Data.Default
-import Data.Maybe
 
 import qualified Data.Sequence as Seq
 

--- a/src/Monomer/Widgets/Containers/Tooltip.hs
+++ b/src/Monomer/Widgets/Containers/Tooltip.hs
@@ -34,7 +34,7 @@ module Monomer.Widgets.Containers.Tooltip (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~), (%~), at)
+import Control.Lens ((&), (^.), (.~))
 import Control.Monad (forM_, when)
 import Data.Default
 import Data.Maybe

--- a/src/Monomer/Widgets/Containers/ZStack.hs
+++ b/src/Monomer/Widgets/Containers/ZStack.hs
@@ -38,12 +38,12 @@ module Monomer.Widgets.Containers.ZStack (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (^?), (.~), (%~), (?~), at, ix)
-import Control.Monad (forM_, void, when)
+import Control.Lens ((&), (^.), (^?), (.~), (%~), at, ix)
+import Control.Monad (void, when)
 import Data.Default
 import Data.Maybe
-import Data.List (foldl', any)
-import Data.Sequence (Seq(..), (<|), (|>))
+import Data.List (foldl')
+import Data.Sequence (Seq(..), (|>))
 import GHC.Generics
 
 import qualified Data.Map.Strict as M

--- a/src/Monomer/Widgets/Single.hs
+++ b/src/Monomer/Widgets/Single.hs
@@ -39,13 +39,12 @@ module Monomer.Widgets.Single (
   createSingle
 ) where
 
-import Control.Exception (AssertionFailed(..), throw)
-import Control.Lens ((&), (^.), (^?), (.~), (%~), _Just)
+import Control.Lens ((&), (^.), (.~), (%~))
 import Control.Monad (when)
 import Data.Default
 import Data.Maybe
 import Data.Sequence (Seq(..), (|>))
-import Data.Typeable (Typeable, cast)
+import Data.Typeable (Typeable)
 
 import qualified Data.Sequence as Seq
 

--- a/src/Monomer/Widgets/Singles/Button.hs
+++ b/src/Monomer/Widgets/Singles/Button.hs
@@ -60,9 +60,9 @@ Configuration options for button:
 - 'multiline': if text may be split in multiple lines.
 - 'maxLines': maximum number of text lines to show.
 - 'ignoreTheme': whether to load default style from theme or start empty.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
-- 'resizeFactorW': flexibility to have more or less horizontal spaced assigned.
-- 'resizeFactorH': flexibility to have more or less vertical spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
+- 'resizeFactorW': flexibility to have more or less horizontal space assigned.
+- 'resizeFactorH': flexibility to have more or less vertical space assigned.
 - 'onFocus': event to raise when focus is received.
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.

--- a/src/Monomer/Widgets/Singles/Checkbox.hs
+++ b/src/Monomer/Widgets/Singles/Checkbox.hs
@@ -43,8 +43,6 @@ import Control.Monad
 import Data.Default
 import Data.Maybe
 
-import qualified Data.Sequence as Seq
-
 import Monomer.Widgets.Single
 
 import qualified Monomer.Lens as L

--- a/src/Monomer/Widgets/Singles/ColorPicker.hs
+++ b/src/Monomer/Widgets/Singles/ColorPicker.hs
@@ -39,12 +39,10 @@ module Monomer.Widgets.Singles.ColorPicker (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~), ALens', abbreviatedFields, makeLensesWith)
-import Data.ByteString (ByteString)
+import Control.Lens (ALens')
 import Data.ByteString.Builder (Builder, toLazyByteString)
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Builder as B

--- a/src/Monomer/Widgets/Singles/ColorPopup.hs
+++ b/src/Monomer/Widgets/Singles/ColorPopup.hs
@@ -35,10 +35,8 @@ module Monomer.Widgets.Singles.ColorPopup (
   colorPopupV_
 ) where
 
-import Control.Applicative ((<|>))
 import Control.Lens ((&), (^.), (.~), (?~), ALens', abbreviatedFields, makeLensesWith, non)
 import Data.Default
-import Data.Text (Text)
 
 import Monomer.Core.Combinators
 import Monomer.Graphics.Types
@@ -46,7 +44,6 @@ import Monomer.Graphics.Types
 import Monomer.Widgets.Composite
 import Monomer.Widgets.Containers.BoxShadow
 import Monomer.Widgets.Containers.Popup
-import Monomer.Widgets.Containers.Stack
 import Monomer.Widgets.Singles.ColorPicker
 import Monomer.Widgets.Singles.ToggleButton
 

--- a/src/Monomer/Widgets/Singles/DateField.hs
+++ b/src/Monomer/Widgets/Singles/DateField.hs
@@ -86,7 +86,7 @@ defaultDateDelim :: Char
 defaultDateDelim = '/'
 
 {-|
-Converter to and form the Day type of the time library. To use types other than
+Converter to and from the Day type of the time library. To use types other than
 Day of said library, this typeclass needs to be implemented.
 --}
 class (Eq a, Ord a, Show a, Typeable a) => DayConverter a where

--- a/src/Monomer/Widgets/Singles/Dial.hs
+++ b/src/Monomer/Widgets/Singles/Dial.hs
@@ -39,10 +39,8 @@ module Monomer.Widgets.Singles.Dial (
 
 import Control.Applicative ((<|>))
 import Control.Lens (ALens', (&), (^.), (.~), (<>~))
-import Control.Monad
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 import Data.Typeable (Typeable, typeOf)
 import GHC.Generics
 import TextShow

--- a/src/Monomer/Widgets/Singles/ExternalLink.hs
+++ b/src/Monomer/Widgets/Singles/ExternalLink.hs
@@ -27,10 +27,8 @@ module Monomer.Widgets.Singles.ExternalLink (
   externalLink_
 ) where
 
-import Control.Applicative ((<|>))
 import Control.Lens ((&), (^.), (.~))
 import Data.Default
-import Data.Maybe
 import Data.Text (Text)
 import System.Process (callCommand)
 

--- a/src/Monomer/Widgets/Singles/ExternalLink.hs
+++ b/src/Monomer/Widgets/Singles/ExternalLink.hs
@@ -48,9 +48,9 @@ Configuration options for externalLink:
 - 'ellipsis': if ellipsis should be used for overflown text.
 - 'multiline': if text may be split in multiple lines.
 - 'maxLines': maximum number of text lines to show.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
-- 'resizeFactorW': flexibility to have more or less horizontal spaced assigned.
-- 'resizeFactorH': flexibility to have more or less vertical spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
+- 'resizeFactorW': flexibility to have more or less horizontal space assigned.
+- 'resizeFactorH': flexibility to have more or less vertical space assigned.
 - 'onFocus': event to raise when focus is received.
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.

--- a/src/Monomer/Widgets/Singles/Image.hs
+++ b/src/Monomer/Widgets/Singles/Image.hs
@@ -43,14 +43,12 @@ import Codec.Picture (DynamicImage, Image(..))
 import Control.Applicative ((<|>))
 import Control.Concurrent
 import Control.Exception (try)
-import Control.Lens ((&), (^.), (.~), (%~), (?~), at)
+import Control.Lens ((&), (^.), (.~), (?~), at)
 import Control.Monad (when)
 import Data.ByteString (ByteString)
-import Data.Char (toLower)
 import Data.Default
 import Data.Map.Strict (Map)
 import Data.Maybe
-import Data.List (isPrefixOf)
 import Data.Text (Text)
 import Data.Typeable (cast)
 import Data.Vector.Storable.ByteString (vectorToByteString)

--- a/src/Monomer/Widgets/Singles/Label.hs
+++ b/src/Monomer/Widgets/Singles/Label.hs
@@ -58,9 +58,9 @@ Configuration options for label.
 - 'multiline': if text may be split in multiple lines.
 - 'maxLines': maximum number of text lines to show.
 - 'ignoreTheme': whether to load default style from theme or start empty.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
-- 'resizeFactorW': flexibility to have more or less horizontal spaced assigned.
-- 'resizeFactorH': flexibility to have more or less vertical spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
+- 'resizeFactorW': flexibility to have more or less horizontal space assigned.
+- 'resizeFactorH': flexibility to have more or less vertical space assigned.
 -}
 data LabelCfg s e = LabelCfg {
   _lscIgnoreTheme :: Maybe Bool,

--- a/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
+++ b/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
@@ -35,20 +35,15 @@ module Monomer.Widgets.Singles.LabeledCheckbox (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (.~))
-import Control.Monad
+import Control.Lens (ALens')
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)
-
-import qualified Data.Sequence as Seq
 
 import Monomer.Widgets.Containers.Base.LabeledItem
 import Monomer.Widgets.Single
 import Monomer.Widgets.Singles.Checkbox
 import Monomer.Widgets.Singles.Label
-
-import qualified Monomer.Lens as L
 
 {-|
 Configuration options for labeledCheckbox:

--- a/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
+++ b/src/Monomer/Widgets/Singles/LabeledCheckbox.hs
@@ -62,9 +62,9 @@ Configuration options for labeledCheckbox:
     - 'ellipsis': if ellipsis should be used for overflown text.
     - 'multiline': if text may be split in multiple lines.
     - 'maxLines': maximum number of text lines to show.
-    - 'resizeFactor': flexibility to have more or less spaced assigned.
-    - 'resizeFactorW': flexibility for more or less horizontal spaced assigned.
-    - 'resizeFactorH': flexibility for more or less vertical spaced assigned.
+    - 'resizeFactor': flexibility to have more or less space assigned.
+    - 'resizeFactorW': flexibility for more or less horizontal space assigned.
+    - 'resizeFactorH': flexibility for more or less vertical space assigned.
 
 - Checkbox related
 

--- a/src/Monomer/Widgets/Singles/LabeledRadio.hs
+++ b/src/Monomer/Widgets/Singles/LabeledRadio.hs
@@ -66,9 +66,9 @@ Configuration options for labeledRadio:
     - 'ellipsis': if ellipsis should be used for overflown text.
     - 'multiline': if text may be split in multiple lines.
     - 'maxLines': maximum number of text lines to show.
-    - 'resizeFactor': flexibility to have more or less spaced assigned.
-    - 'resizeFactorW': flexibility for more or less horizontal spaced assigned.
-    - 'resizeFactorH': flexibility for more or less vertical spaced assigned.
+    - 'resizeFactor': flexibility to have more or less space assigned.
+    - 'resizeFactorW': flexibility for more or less horizontal space assigned.
+    - 'resizeFactorH': flexibility for more or less vertical space assigned.
 
 - Radio related
 

--- a/src/Monomer/Widgets/Singles/LabeledRadio.hs
+++ b/src/Monomer/Widgets/Singles/LabeledRadio.hs
@@ -37,21 +37,17 @@ module Monomer.Widgets.Singles.LabeledRadio (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (.~))
+import Control.Lens (ALens')
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)
 import Data.Typeable (typeOf)
 import TextShow
 
-import qualified Data.Sequence as Seq
-
 import Monomer.Widgets.Containers.Base.LabeledItem
 import Monomer.Widgets.Single
 import Monomer.Widgets.Singles.Label
 import Monomer.Widgets.Singles.Radio
-
-import qualified Monomer.Lens as L
 
 {-|
 Configuration options for labeledRadio:

--- a/src/Monomer/Widgets/Singles/OptionButton.hs
+++ b/src/Monomer/Widgets/Singles/OptionButton.hs
@@ -18,7 +18,7 @@ Its behavior is equivalent to "Monomer.Widgets.Singles.Radio" and
 
 This widget, and the associated "Monomer.Widgets.Singles.ToggleButton", uses two
 separate styles for the On and Off states which can be modified individually for
-the theme. If you use any of the the standard style functions (styleBasic,
+the theme. If you use any of the standard style functions (styleBasic,
 styleHover, etc) in an optionButton/toggleButton these changes will apply to
 both On and Off states, except for the color related styles. The reason is that,
 in general, the font and padding will be the same for both states, but the

--- a/src/Monomer/Widgets/Singles/OptionButton.hs
+++ b/src/Monomer/Widgets/Singles/OptionButton.hs
@@ -85,9 +85,9 @@ Configuration options for optionButton:
 - 'ellipsis': if ellipsis should be used for overflown text.
 - 'multiline': if text may be split in multiple lines.
 - 'maxLines': maximum number of text lines to show.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
-- 'resizeFactorW': flexibility to have more or less horizontal spaced assigned.
-- 'resizeFactorH': flexibility to have more or less vertical spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
+- 'resizeFactorW': flexibility to have more or less horizontal space assigned.
+- 'resizeFactorH': flexibility to have more or less vertical space assigned.
 - 'onFocus': event to raise when focus is received.
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.

--- a/src/Monomer/Widgets/Singles/OptionButton.hs
+++ b/src/Monomer/Widgets/Singles/OptionButton.hs
@@ -59,8 +59,7 @@ module Monomer.Widgets.Singles.OptionButton (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens (ALens', Lens', (&), (^.), (^?), (.~), (?~), _Just)
-import Control.Monad
+import Control.Lens (ALens', Lens', (&), (^.), (.~), _Just)
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)

--- a/src/Monomer/Widgets/Singles/Radio.hs
+++ b/src/Monomer/Widgets/Singles/Radio.hs
@@ -43,7 +43,6 @@ import Control.Lens (ALens', (&), (^.), (.~))
 import Control.Monad
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 import Data.Typeable (Typeable, typeOf)
 import TextShow
 

--- a/src/Monomer/Widgets/Singles/SeparatorLine.hs
+++ b/src/Monomer/Widgets/Singles/SeparatorLine.hs
@@ -38,7 +38,6 @@ import Control.Applicative ((<|>))
 import Control.Lens ((^.))
 import Data.Default
 import Data.Maybe
-import Data.Tuple
 
 import Monomer.Widgets.Single
 

--- a/src/Monomer/Widgets/Singles/SeparatorLine.hs
+++ b/src/Monomer/Widgets/Singles/SeparatorLine.hs
@@ -47,7 +47,7 @@ import qualified Monomer.Core.Lens as L
 Configuration options for separatorLine:
 
 - 'width': the max width of the line.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
 -}
 data SeparatorLineCfg = SeparatorLineCfg {
   _slcWidth :: Maybe Double,

--- a/src/Monomer/Widgets/Singles/Slider.hs
+++ b/src/Monomer/Widgets/Singles/Slider.hs
@@ -46,7 +46,6 @@ import Control.Lens (ALens', (&), (^.), (.~), (%~), (<>~))
 import Control.Monad
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 import Data.Typeable (Typeable, typeOf)
 import GHC.Generics
 import TextShow

--- a/src/Monomer/Widgets/Singles/Spacer.hs
+++ b/src/Monomer/Widgets/Singles/Spacer.hs
@@ -54,7 +54,7 @@ import qualified Monomer.Core.Lens as L
 Configuration options for spacer widget:
 
 - 'width': the max width for spacer, the reference for filler.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
 -}
 data SpacerCfg = SpacerCfg {
   _spcWidth :: Maybe Double,

--- a/src/Monomer/Widgets/Singles/Spacer.hs
+++ b/src/Monomer/Widgets/Singles/Spacer.hs
@@ -45,7 +45,6 @@ import Control.Applicative ((<|>))
 import Control.Lens ((^.))
 import Data.Default
 import Data.Maybe
-import Data.Tuple
 
 import Monomer.Widgets.Single
 

--- a/src/Monomer/Widgets/Singles/TimeField.hs
+++ b/src/Monomer/Widgets/Singles/TimeField.hs
@@ -82,7 +82,7 @@ defaultTimeDelim :: Char
 defaultTimeDelim = ':'
 
 {-|
-Converter to and form the 'TimeOfDay' type of the time library. To use types
+Converter to and from the 'TimeOfDay' type of the time library. To use types
 other than 'TimeOfDay' of said library, this typeclass needs to be implemented.
 --}
 class (Eq a, Ord a, Show a, Typeable a) => TimeOfDayConverter a where

--- a/src/Monomer/Widgets/Singles/ToggleButton.hs
+++ b/src/Monomer/Widgets/Singles/ToggleButton.hs
@@ -34,12 +34,9 @@ module Monomer.Widgets.Singles.ToggleButton (
   toggleButtonD_
 ) where
 
-import Control.Applicative ((<|>))
-import Control.Lens (ALens', (&), (^.), (^?), (.~), (?~), _Just)
+import Control.Lens (ALens', (&), (.~))
 import Data.Default
 import Data.Text (Text)
-
-import qualified Data.Sequence as Seq
 
 import Monomer.Widgets.Single
 import Monomer.Widgets.Singles.OptionButton

--- a/src/Monomer/Widgets/Singles/ToggleButton.hs
+++ b/src/Monomer/Widgets/Singles/ToggleButton.hs
@@ -52,9 +52,9 @@ Configuration options for toggleButton:
 - 'ellipsis': if ellipsis should be used for overflown text.
 - 'multiline': if text may be split in multiple lines.
 - 'maxLines': maximum number of text lines to show.
-- 'resizeFactor': flexibility to have more or less spaced assigned.
-- 'resizeFactorW': flexibility to have more or less horizontal spaced assigned.
-- 'resizeFactorH': flexibility to have more or less vertical spaced assigned.
+- 'resizeFactor': flexibility to have more or less space assigned.
+- 'resizeFactorW': flexibility to have more or less horizontal space assigned.
+- 'resizeFactorH': flexibility to have more or less vertical space assigned.
 - 'onFocus': event to raise when focus is received.
 - 'onFocusReq': 'WidgetRequest' to generate when focus is received.
 - 'onBlur': event to raise when focus is lost.

--- a/src/Monomer/Widgets/Util/Drawing.hs
+++ b/src/Monomer/Widgets/Util/Drawing.hs
@@ -39,18 +39,16 @@ module Monomer.Widgets.Util.Drawing (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (^?), (^?!), (.~), non)
-import Control.Monad (forM_, void, when)
+import Control.Lens ((^.), (^?!), non)
+import Control.Monad (forM_, when)
 import Data.Default
 import Data.Maybe
-import Data.Text (Text)
 
 import Monomer.Core
 import Monomer.Graphics.Types
 
 import qualified Monomer.Common.Lens as L
 import qualified Monomer.Core.Lens as L
-import qualified Monomer.Graphics.Lens as L
 
 -- | Performs the provided drawing operations with an active scissor, and then
 -- | disables it.

--- a/src/Monomer/Widgets/Util/Focus.hs
+++ b/src/Monomer/Widgets/Util/Focus.hs
@@ -26,10 +26,7 @@ module Monomer.Widgets.Util.Focus (
   handleFocusChange
 ) where
 
-import Control.Lens ((&), (^.), (.~), (%~))
-import Data.Maybe
-import Data.Sequence (Seq(..), (|>))
-import Data.Typeable (Typeable)
+import Control.Lens ((^.))
 
 import qualified Data.Sequence as Seq
 

--- a/src/Monomer/Widgets/Util/Hover.hs
+++ b/src/Monomer/Widgets/Util/Hover.hs
@@ -30,7 +30,7 @@ module Monomer.Widgets.Util.Hover (
   isNodeInfoInOverlay
 ) where
 
-import Control.Lens ((&), (^.), (^?), _1, _Just)
+import Control.Lens ((^.), (^?), _1, _Just)
 import Data.Maybe
 
 import qualified Data.Sequence as Seq

--- a/src/Monomer/Widgets/Util/Keyboard.hs
+++ b/src/Monomer/Widgets/Util/Keyboard.hs
@@ -19,10 +19,6 @@ module Monomer.Widgets.Util.Keyboard (
   isKeyboardRedo
 ) where
 
-import Data.Maybe (fromMaybe)
-
-import qualified Data.Map as M
-
 import Monomer.Core
 import Monomer.Event.Keyboard
 import Monomer.Event.Types

--- a/src/Monomer/Widgets/Util/Style.hs
+++ b/src/Monomer/Widgets/Util/Style.hs
@@ -28,13 +28,11 @@ module Monomer.Widgets.Util.Style (
   childOfFocusedStyle
 ) where
 
-import Control.Applicative ((<|>))
 import Control.Lens hiding ((<|), (|>))
 
-import Data.Bits (xor)
 import Data.Default
 import Data.Maybe
-import Data.Sequence (Seq(..), (<|), (|>))
+import Data.Sequence ((<|), (|>))
 
 import qualified Data.Sequence as Seq
 

--- a/src/Monomer/Widgets/Util/Text.hs
+++ b/src/Monomer/Widgets/Util/Text.hs
@@ -18,9 +18,8 @@ module Monomer.Widgets.Util.Text (
   getTextGlyphs
 ) where
 
-import Control.Lens ((&), (^.), (+~))
-import Data.Default
-import Data.Sequence (Seq(..), (<|), (|>))
+import Control.Lens ((^.))
+import Data.Sequence (Seq(..))
 import Data.Text (Text)
 
 import Monomer.Core

--- a/src/Monomer/Widgets/Util/Theme.hs
+++ b/src/Monomer/Widgets/Util/Theme.hs
@@ -14,9 +14,8 @@ Helper functions for loading theme values.
 
 module Monomer.Widgets.Util.Theme where
 
-import Control.Lens (Lens', (&), (^.), (^?), (.~), (?~), (<>~), at, non)
+import Control.Lens (Lens', (&), (^.), (.~), (<>~), at, non)
 import Data.Default
-import Data.Maybe
 
 import Monomer.Core.StyleTypes
 import Monomer.Core.ThemeTypes

--- a/src/Monomer/Widgets/Util/Widget.hs
+++ b/src/Monomer/Widgets/Util/Widget.hs
@@ -39,15 +39,11 @@ module Monomer.Widgets.Util.Widget (
 ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Lens ((&), (^#), (#~), (^.), (^?), (.~), (%~), _Just)
+import Control.Lens ((&), (^#), (#~), (^.), (.~), (%~))
 import Data.Default
-import Data.Maybe
-import Data.Map.Strict (Map)
-import Data.Sequence (Seq(..), (<|))
-import Data.Text (Text)
+import Data.Sequence ((<|))
 import Data.Typeable (Typeable, cast)
 
-import qualified Data.Map.Strict as M
 import qualified Data.Sequence as Seq
 
 import Monomer.Common


### PR DESCRIPTION
I removed unused imports and fixed some typos in the documentation.