### PR TITLE
Add more animation widgets

### DIFF
--- a/monomer.cabal
+++ b/monomer.cabal
@@ -87,6 +87,7 @@ library
       Monomer.Widgets.Animation.Slide
       Monomer.Widgets.Animation.Transform
       Monomer.Widgets.Animation.Types
+      Monomer.Widgets.Animation.Wipe
       Monomer.Widgets.Animation.Zoom
       Monomer.Widgets.Composite
       Monomer.Widgets.Container
@@ -533,6 +534,7 @@ test-suite monomer-test
       Monomer.Widgets.Animation.FadeSpec
       Monomer.Widgets.Animation.SlideSpec
       Monomer.Widgets.Animation.TransformSpec
+      Monomer.Widgets.Animation.WipeSpec
       Monomer.Widgets.Animation.ZoomSpec
       Monomer.Widgets.CompositeSpec
       Monomer.Widgets.Containers.AlertSpec

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -84,6 +84,7 @@ library
       Monomer.Widgets
       Monomer.Widgets.Animation
       Monomer.Widgets.Animation.Fade
+      Monomer.Widgets.Animation.Shake
       Monomer.Widgets.Animation.Slide
       Monomer.Widgets.Animation.Transform
       Monomer.Widgets.Animation.Types
@@ -532,6 +533,7 @@ test-suite monomer-test
       Monomer.TestEventUtil
       Monomer.TestUtil
       Monomer.Widgets.Animation.FadeSpec
+      Monomer.Widgets.Animation.ShakeSpec
       Monomer.Widgets.Animation.SlideSpec
       Monomer.Widgets.Animation.TransformSpec
       Monomer.Widgets.Animation.WipeSpec

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -87,6 +87,7 @@ library
       Monomer.Widgets.Animation.Slide
       Monomer.Widgets.Animation.Transform
       Monomer.Widgets.Animation.Types
+      Monomer.Widgets.Animation.Zoom
       Monomer.Widgets.Composite
       Monomer.Widgets.Container
       Monomer.Widgets.Containers.Alert
@@ -532,6 +533,7 @@ test-suite monomer-test
       Monomer.Widgets.Animation.FadeSpec
       Monomer.Widgets.Animation.SlideSpec
       Monomer.Widgets.Animation.TransformSpec
+      Monomer.Widgets.Animation.ZoomSpec
       Monomer.Widgets.CompositeSpec
       Monomer.Widgets.Containers.AlertSpec
       Monomer.Widgets.Containers.BoxShadowSpec

--- a/monomer.cabal
+++ b/monomer.cabal
@@ -85,6 +85,7 @@ library
       Monomer.Widgets.Animation
       Monomer.Widgets.Animation.Fade
       Monomer.Widgets.Animation.Slide
+      Monomer.Widgets.Animation.Transform
       Monomer.Widgets.Animation.Types
       Monomer.Widgets.Composite
       Monomer.Widgets.Container
@@ -530,6 +531,7 @@ test-suite monomer-test
       Monomer.TestUtil
       Monomer.Widgets.Animation.FadeSpec
       Monomer.Widgets.Animation.SlideSpec
+      Monomer.Widgets.Animation.TransformSpec
       Monomer.Widgets.CompositeSpec
       Monomer.Widgets.Containers.AlertSpec
       Monomer.Widgets.Containers.BoxShadowSpec

--- a/src/Monomer/Core/Combinators.hs
+++ b/src/Monomer/Core/Combinators.hs
@@ -521,6 +521,10 @@ class CmbOnLoadError t e a | t -> e a where
 class CmbOnFinished t e | t -> e where
   onFinished :: e -> t
 
+-- | On finished WidgetRequest.
+class CmbOnFinishedReq t s e | t -> s e where
+  onFinishedReq :: WidgetRequest s e -> t
+
 -- | Width combinator.
 class CmbWidth t where
   width :: Double -> t

--- a/src/Monomer/Widgets.hs
+++ b/src/Monomer/Widgets.hs
@@ -12,9 +12,7 @@ module Monomer.Widgets (
   -- * Composite widget
   module Monomer.Widgets.Composite,
   -- * Animation
-  module Monomer.Widgets.Animation.Fade,
-  module Monomer.Widgets.Animation.Slide,
-  module Monomer.Widgets.Animation.Types,
+  module Monomer.Widgets.Animation,
   -- * Containers
   module Monomer.Widgets.Containers.Alert,
   module Monomer.Widgets.Containers.Box,
@@ -61,9 +59,7 @@ module Monomer.Widgets (
 
 import Monomer.Widgets.Composite
 
-import Monomer.Widgets.Animation.Fade
-import Monomer.Widgets.Animation.Slide
-import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Animation
 
 import Monomer.Widgets.Containers.Alert
 import Monomer.Widgets.Containers.Box

--- a/src/Monomer/Widgets/Animation.hs
+++ b/src/Monomer/Widgets/Animation.hs
@@ -11,9 +11,11 @@ Widgets implementing different types of animations.
 module Monomer.Widgets.Animation (
   module Monomer.Widgets.Animation.Fade,
   module Monomer.Widgets.Animation.Slide,
+  module Monomer.Widgets.Animation.Transform,
   module Monomer.Widgets.Animation.Types
 ) where
 
 import Monomer.Widgets.Animation.Fade
 import Monomer.Widgets.Animation.Slide
+import Monomer.Widgets.Animation.Transform
 import Monomer.Widgets.Animation.Types

--- a/src/Monomer/Widgets/Animation.hs
+++ b/src/Monomer/Widgets/Animation.hs
@@ -13,6 +13,7 @@ module Monomer.Widgets.Animation (
   module Monomer.Widgets.Animation.Slide,
   module Monomer.Widgets.Animation.Transform,
   module Monomer.Widgets.Animation.Types,
+  module Monomer.Widgets.Animation.Wipe,
   module Monomer.Widgets.Animation.Zoom
 ) where
 
@@ -20,4 +21,5 @@ import Monomer.Widgets.Animation.Fade
 import Monomer.Widgets.Animation.Slide
 import Monomer.Widgets.Animation.Transform
 import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Animation.Wipe
 import Monomer.Widgets.Animation.Zoom

--- a/src/Monomer/Widgets/Animation.hs
+++ b/src/Monomer/Widgets/Animation.hs
@@ -10,6 +10,7 @@ Widgets implementing different types of animations.
 -}
 module Monomer.Widgets.Animation (
   module Monomer.Widgets.Animation.Fade,
+  module Monomer.Widgets.Animation.Shake,
   module Monomer.Widgets.Animation.Slide,
   module Monomer.Widgets.Animation.Transform,
   module Monomer.Widgets.Animation.Types,
@@ -18,6 +19,7 @@ module Monomer.Widgets.Animation (
 ) where
 
 import Monomer.Widgets.Animation.Fade
+import Monomer.Widgets.Animation.Shake
 import Monomer.Widgets.Animation.Slide
 import Monomer.Widgets.Animation.Transform
 import Monomer.Widgets.Animation.Types

--- a/src/Monomer/Widgets/Animation.hs
+++ b/src/Monomer/Widgets/Animation.hs
@@ -12,10 +12,12 @@ module Monomer.Widgets.Animation (
   module Monomer.Widgets.Animation.Fade,
   module Monomer.Widgets.Animation.Slide,
   module Monomer.Widgets.Animation.Transform,
-  module Monomer.Widgets.Animation.Types
+  module Monomer.Widgets.Animation.Types,
+  module Monomer.Widgets.Animation.Zoom
 ) where
 
 import Monomer.Widgets.Animation.Fade
 import Monomer.Widgets.Animation.Slide
 import Monomer.Widgets.Animation.Transform
 import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Animation.Zoom

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -12,12 +12,7 @@ Messages:
 
 - Accepts an 'AnimationMsg', used to control the state of the animation.
 -}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Fade (
   -- * Configuration
@@ -29,18 +24,12 @@ module Monomer.Widgets.Animation.Fade (
   animFadeOut_
 ) where
 
-import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~))
-import Control.Monad (when)
+import Control.Lens ((&), (.~))
 import Data.Default
 import Data.Maybe
-import Data.Typeable (cast)
-import GHC.Generics
-
-import qualified Data.Sequence as Seq
 
 import Monomer.Widgets.Container
-import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Animation.Transform
 
 import qualified Monomer.Lens as L
 
@@ -52,23 +41,17 @@ Configuration options for fade:
 - 'onFinished': event to raise when animation is complete.
 -}
 data FadeCfg e = FadeCfg {
-  _fdcAutoStart :: Maybe Bool,
-  _fdcDuration :: Maybe Millisecond,
-  _fdcOnFinished :: [e]
+  _fdcTransformCfg :: TransformCfg e
 } deriving (Eq, Show)
 
 instance Default (FadeCfg e) where
   def = FadeCfg {
-    _fdcAutoStart = Nothing,
-    _fdcDuration = Nothing,
-    _fdcOnFinished = []
+    _fdcTransformCfg = def
   }
 
 instance Semigroup (FadeCfg e) where
   (<>) fc1 fc2 = FadeCfg {
-    _fdcAutoStart = _fdcAutoStart fc2 <|> _fdcAutoStart fc1,
-    _fdcDuration = _fdcDuration fc2 <|> _fdcDuration fc1,
-    _fdcOnFinished = _fdcOnFinished fc1 <> _fdcOnFinished fc2
+    _fdcTransformCfg = _fdcTransformCfg fc1 <> _fdcTransformCfg fc2
   }
 
 instance Monoid (FadeCfg e) where
@@ -76,28 +59,17 @@ instance Monoid (FadeCfg e) where
 
 instance CmbAutoStart (FadeCfg e) where
   autoStart_ start = def {
-    _fdcAutoStart = Just start
+    _fdcTransformCfg = autoStart_ start
   }
 
 instance CmbDuration (FadeCfg e) Millisecond where
   duration dur = def {
-    _fdcDuration = Just dur
+    _fdcTransformCfg = duration dur
   }
 
 instance CmbOnFinished (FadeCfg e) e where
   onFinished fn = def {
-    _fdcOnFinished = [fn]
-  }
-
-data FadeState = FadeState {
-  _fdsRunning :: Bool,
-  _fdsStartTs :: Millisecond
-} deriving (Eq, Show, Generic)
-
-instance Default FadeState where
-  def = FadeState {
-    _fdsRunning = False,
-    _fdsStartTs = 0
+    _fdcTransformCfg = onFinished fn
   }
 
 -- | Animates a widget from not visible state to fully visible.
@@ -113,9 +85,8 @@ animFadeIn_
   => [FadeCfg e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
-animFadeIn_ configs managed = makeNode "animFadeIn" widget managed where
-  config = mconcat configs
-  widget = makeFade True config def
+animFadeIn_ configs managed = makeNode configs managed True
+  & L.info . L.widgetType .~ "animFadeIn"
 
 -- | Animates a widget from visible state to not visible.
 animFadeOut
@@ -130,78 +101,22 @@ animFadeOut_
   => [FadeCfg e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
-animFadeOut_ configs managed = makeNode "animFadeOut" widget managed where
-  config = mconcat configs
-  widget = makeFade False config def
+animFadeOut_ configs managed = makeNode configs managed False
+  & L.info . L.widgetType .~ "animFadeOut"
 
 makeNode
-  :: WidgetEvent e => WidgetType -> Widget s e -> WidgetNode s e -> WidgetNode s e
-makeNode wType widget managedWidget = defaultWidgetNode wType widget
-  & L.info . L.focusable .~ False
-  & L.children .~ Seq.singleton managedWidget
-
-makeFade :: WidgetEvent e => Bool -> FadeCfg e -> FadeState -> Widget s e
-makeFade isFadeIn config state = widget where
-  widget = createContainer state def {
-    containerInit = init,
-    containerMerge = merge,
-    containerHandleMessage = handleMessage,
-    containerRender = render,
-    containerRenderAfter = renderPost
-  }
-
-  FadeState running start = state
-  autoStart = fromMaybe False (_fdcAutoStart config)
-  duration = fromMaybe 500 (_fdcDuration config)
-  period = 20
-  steps = fromIntegral $ duration `div` period
-
-  finishedReq node ts = delayedMessage node (AnimationFinished ts) duration
-  renderReq wenv node = req where
-    widgetId = node ^. L.info . L.widgetId
-    req = RenderEvery widgetId period (Just steps)
-
-  init wenv node = result where
-    ts = wenv ^. L.timestamp
-    newNode = node
-      & L.widget .~ makeFade isFadeIn config (FadeState True ts)
-    result
-      | autoStart = resultReqs newNode [finishedReq node ts, renderReq wenv node]
-      | otherwise = resultNode node
-
-  merge wenv node oldNode oldState = resultNode newNode where
-    newNode = node
-      & L.widget .~ makeFade isFadeIn config oldState
-
-  handleMessage wenv node target message = result where
-    result = cast message >>= Just . handleAnimateMsg wenv node
-
-  handleAnimateMsg wenv node msg = result where
-    widgetId = node ^. L.info . L.widgetId
-    ts = wenv ^. L.timestamp
-    startState = FadeState True ts
-    startReqs = [finishedReq node ts, renderReq wenv node]
-
-    newNode newState = node
-      & L.widget .~ makeFade isFadeIn config newState
-    result = case msg of
-      AnimationStart -> resultReqs (newNode startState) startReqs
-      AnimationStop -> resultReqs (newNode def) [RenderStop widgetId]
-      AnimationFinished ts'
-        | isRelevant -> resultEvts node (_fdcOnFinished config)
-        | otherwise -> resultNode node
-        where isRelevant = _fdsRunning state && ts' == _fdsStartTs state
-
-  render wenv node renderer = do
-    saveContext renderer
-    when running $
-      setGlobalAlpha renderer alpha
-    where
-      ts = wenv ^. L.timestamp
-      currStep = clampAlpha $ fromIntegral (ts - start) / fromIntegral duration
-      alpha
-        | isFadeIn = currStep
-        | otherwise = 1 - currStep
-
-  renderPost wenv node renderer = do
-    restoreContext renderer
+  :: WidgetEvent e
+  => [FadeCfg e]
+  -> WidgetNode s e
+  -> Bool
+  -> WidgetNode s e
+makeNode configs managed isFadeIn = node where
+  node = animTransform_ [_fdcTransformCfg] f managed
+  f t _ = [animGlobalAlpha $ alpha t]
+  alpha t = if isFadeIn
+    then (currStep t)
+    else 1-(currStep t)
+  currStep t = clampAlpha $ t/(fromIntegral dur)
+  dur = fromMaybe 500 _tfcDuration
+  TransformCfg{..} = _fdcTransformCfg
+  FadeCfg{..} = mconcat configs

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -41,37 +41,43 @@ Configuration options for fade:
 - 'autoStart': whether the first time the widget is added, animation should run.
 - 'duration': how long the animation lasts in ms.
 - 'onFinished': event to raise when animation is complete.
+- 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 -}
-data FadeCfg e = FadeCfg {
-  _fdcTransformCfg :: TransformCfg e
+data FadeCfg s e = FadeCfg {
+  _fdcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 
-instance Default (FadeCfg e) where
+instance Default (FadeCfg s e) where
   def = FadeCfg {
     _fdcTransformCfg = def
   }
 
-instance Semigroup (FadeCfg e) where
+instance Semigroup (FadeCfg s e) where
   (<>) fc1 fc2 = FadeCfg {
     _fdcTransformCfg = _fdcTransformCfg fc1 <> _fdcTransformCfg fc2
   }
 
-instance Monoid (FadeCfg e) where
+instance Monoid (FadeCfg s e) where
   mempty = def
 
-instance CmbAutoStart (FadeCfg e) where
+instance CmbAutoStart (FadeCfg s e) where
   autoStart_ start = def {
     _fdcTransformCfg = autoStart_ start
   }
 
-instance CmbDuration (FadeCfg e) Millisecond where
+instance CmbDuration (FadeCfg s e) Millisecond where
   duration dur = def {
     _fdcTransformCfg = duration dur
   }
 
-instance CmbOnFinished (FadeCfg e) e where
-  onFinished fn = def {
-    _fdcTransformCfg = onFinished fn
+instance WidgetEvent e => CmbOnFinished (FadeCfg s e) e where
+  onFinished handler = def {
+    _fdcTransformCfg = onFinished handler
+  }
+
+instance CmbOnFinishedReq (FadeCfg s e) s e where
+  onFinishedReq req = def {
+    _fdcTransformCfg = onFinishedReq req
   }
 
 -- | Animates a widget from not visible state to fully visible.
@@ -84,7 +90,7 @@ animFadeIn managed = animFadeIn_ def managed
 -- | Animates a widget from not visible state to fully visible. Accepts config.
 animFadeIn_
   :: WidgetEvent e
-  => [FadeCfg e]     -- ^ The config options.
+  => [FadeCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animFadeIn_ configs managed = makeNode configs managed True
@@ -100,7 +106,7 @@ animFadeOut managed = animFadeOut_ def managed
 -- | Animates a widget from visible state to not visible. Accepts config.
 animFadeOut_
   :: WidgetEvent e
-  => [FadeCfg e]     -- ^ The config options.
+  => [FadeCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animFadeOut_ configs managed = makeNode configs managed False
@@ -108,7 +114,7 @@ animFadeOut_ configs managed = makeNode configs managed False
 
 makeNode
   :: WidgetEvent e
-  => [FadeCfg e]
+  => [FadeCfg s e]
   -> WidgetNode s e
   -> Bool
   -> WidgetNode s e

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -44,7 +44,7 @@ Configuration options for fade:
 - 'onFinished': event to raise when animation is complete.
 - 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 -}
-data FadeCfg s e = FadeCfg {
+newtype FadeCfg s e = FadeCfg {
   _fdcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -15,6 +15,7 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Fade (
   -- * Configuration

--- a/src/Monomer/Widgets/Animation/Fade.hs
+++ b/src/Monomer/Widgets/Animation/Fade.hs
@@ -12,6 +12,8 @@ Messages:
 
 - Accepts an 'AnimationMsg', used to control the state of the animation.
 -}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Fade (

--- a/src/Monomer/Widgets/Animation/Shake.hs
+++ b/src/Monomer/Widgets/Animation/Shake.hs
@@ -12,7 +12,8 @@ Messages:
 
 - Accepts a 'AnimationMsg', used to control the state of the animation.
 -}
-
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Shake (

--- a/src/Monomer/Widgets/Animation/Shake.hs
+++ b/src/Monomer/Widgets/Animation/Shake.hs
@@ -1,0 +1,159 @@
+{-|
+Module      : Monomer.Widgets.Animation.Shake
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Shake animation widget. Wraps a child widget whose content will be animated.
+
+Messages:
+
+- Accepts a 'AnimationMsg', used to control the state of the animation.
+-}
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Monomer.Widgets.Animation.Shake (
+  -- * Configuration
+  ShakeCfg,
+  shakeH,
+  shakeV,
+  shakeR,
+  shakeS,
+  shakeAmplitude,
+  shakeFrequency,
+  -- * Constructors
+  animShake,
+  animShake_
+) where
+
+import Control.Applicative ((<|>))
+import Control.Lens ((&), (.~))
+import Data.Default
+import Data.Maybe
+
+import Monomer.Helper
+import Monomer.Widgets.Container
+import Monomer.Widgets.Animation.Transform
+
+import qualified Monomer.Lens as L
+
+data ShakeDirection
+  = ShakeH
+  | ShakeV
+  | ShakeR
+  | ShakeS
+  deriving (Eq, Show)
+
+{-|
+Configuration options for shake:
+
+- 'autoStart': whether the first time the widget is added, animation should run.
+- 'duration': how long the animation lasts in ms.
+- 'onFinished': event to raise when animation is complete.
+- 'shakeAmplitude': amplitude of the animation. Defaults to 0.1.
+- 'shakeFrequency': frequency of the animation. Defaults to 2.
+- Individual combinators for direction.
+-}
+data ShakeCfg e = ShakeCfg {
+  _shcDirection :: Maybe ShakeDirection,
+  _shcAmplitude :: Maybe Double,
+  _shcFrequency :: Maybe Int,
+  _shcTransformCfg :: TransformCfg e
+} deriving (Eq, Show)
+
+instance Default (ShakeCfg e) where
+  def = ShakeCfg {
+    _shcDirection = Nothing,
+    _shcAmplitude = Nothing,
+    _shcFrequency = Nothing,
+    _shcTransformCfg = def
+  }
+
+instance Semigroup (ShakeCfg e) where
+  (<>) sc1 sc2 = ShakeCfg {
+    _shcDirection = _shcDirection sc2 <|> _shcDirection sc1,
+    _shcAmplitude = _shcAmplitude sc2 <|> _shcAmplitude sc1,
+    _shcFrequency = _shcFrequency sc2 <|> _shcFrequency sc1,
+    _shcTransformCfg = _shcTransformCfg sc1 <> _shcTransformCfg sc2
+  }
+
+instance Monoid (ShakeCfg e) where
+  mempty = def
+
+instance CmbAutoStart (ShakeCfg e) where
+  autoStart_ start = def {
+    _shcTransformCfg = autoStart_ start
+  }
+
+instance CmbDuration (ShakeCfg e) Millisecond where
+  duration dur = def {
+    _shcTransformCfg = duration dur
+  }
+
+instance CmbOnFinished (ShakeCfg e) e where
+  onFinished fn = def {
+    _shcTransformCfg = onFinished fn
+  }
+
+-- | Shake horizontally.
+shakeH :: ShakeCfg e
+shakeH = def { _shcDirection = Just ShakeH }
+
+-- | Shake vertically.
+shakeV :: ShakeCfg e
+shakeV = def { _shcDirection = Just ShakeV }
+
+-- | Shake by rotating.
+shakeR :: ShakeCfg e
+shakeR = def { _shcDirection = Just ShakeR }
+
+-- | Shake by scaling.
+shakeS :: ShakeCfg e
+shakeS = def { _shcDirection = Just ShakeS }
+
+-- | Amplitude of the animation. Defaults to 1.
+shakeAmplitude :: Double -> ShakeCfg e
+shakeAmplitude amp = def { _shcAmplitude = Just amp }
+
+-- | Frequency of the animation. Defaults to 2.
+shakeFrequency :: Int -> ShakeCfg e
+shakeFrequency freq = def { _shcFrequency = Just freq }
+
+-- | Shakes a widget.
+animShake
+  :: WidgetEvent e
+  => WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animShake managed = animShake_ def managed
+
+-- | Shakes a widget. Accepts config.
+animShake_
+  :: WidgetEvent e
+  => [ShakeCfg e]    -- ^ The config options.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animShake_ configs managed = node where
+  node = animTransform_ [_shcTransformCfg] f managed
+    & L.info . L.widgetType .~ "animShake"
+  f t vp@(Rect _ _ w h) = (noScissor vp) <> case dir of
+    ShakeH -> [animTranslation $ Point ((step t)*w) 0]
+    ShakeV -> [animTranslation $ Point 0 ((step t)*h)]
+    ShakeR -> [animRotation $ (step t)*180]
+    ShakeS ->
+      [ animTranslation $ Point ((1-(ss t))*w/2) ((1-(ss t))*h/2)
+      , animScale $ Point (ss t) (ss t)
+      ]
+  noScissor (Rect x y w h) =
+    [animScissor $ Rect (x-w*10) (y-h*10) (w*20) (h*20)]
+  step t = (sin $ (fs t)*freq*2*pi)*amp
+  ss t = 1-(amp/2)+(cos $ (fs t)*freq*2*pi)*amp/2
+  fs t = clamp 0 1 $ t/(fromIntegral dur)
+  dir = fromMaybe ShakeH _shcDirection
+  amp = fromMaybe 0.1 _shcAmplitude
+  freq = fromIntegral $ fromMaybe 2 _shcFrequency
+  dur = fromMaybe 500 _tfcDuration
+  TransformCfg{..} = _shcTransformCfg
+  ShakeCfg{..} = mconcat configs

--- a/src/Monomer/Widgets/Animation/Shake.hs
+++ b/src/Monomer/Widgets/Animation/Shake.hs
@@ -15,6 +15,7 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Shake (
   -- * Configuration

--- a/src/Monomer/Widgets/Animation/Shake.hs
+++ b/src/Monomer/Widgets/Animation/Shake.hs
@@ -54,18 +54,19 @@ Configuration options for shake:
 - 'autoStart': whether the first time the widget is added, animation should run.
 - 'duration': how long the animation lasts in ms.
 - 'onFinished': event to raise when animation is complete.
+- 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 - 'shakeAmplitude': amplitude of the animation. Defaults to 0.1.
 - 'shakeFrequency': frequency of the animation. Defaults to 2.
 - Individual combinators for direction.
 -}
-data ShakeCfg e = ShakeCfg {
+data ShakeCfg s e = ShakeCfg {
   _shcDirection :: Maybe ShakeDirection,
   _shcAmplitude :: Maybe Double,
   _shcFrequency :: Maybe Int,
-  _shcTransformCfg :: TransformCfg e
+  _shcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 
-instance Default (ShakeCfg e) where
+instance Default (ShakeCfg s e) where
   def = ShakeCfg {
     _shcDirection = Nothing,
     _shcAmplitude = Nothing,
@@ -73,7 +74,7 @@ instance Default (ShakeCfg e) where
     _shcTransformCfg = def
   }
 
-instance Semigroup (ShakeCfg e) where
+instance Semigroup (ShakeCfg s e) where
   (<>) sc1 sc2 = ShakeCfg {
     _shcDirection = _shcDirection sc2 <|> _shcDirection sc1,
     _shcAmplitude = _shcAmplitude sc2 <|> _shcAmplitude sc1,
@@ -81,46 +82,51 @@ instance Semigroup (ShakeCfg e) where
     _shcTransformCfg = _shcTransformCfg sc1 <> _shcTransformCfg sc2
   }
 
-instance Monoid (ShakeCfg e) where
+instance Monoid (ShakeCfg s e) where
   mempty = def
 
-instance CmbAutoStart (ShakeCfg e) where
+instance CmbAutoStart (ShakeCfg s e) where
   autoStart_ start = def {
     _shcTransformCfg = autoStart_ start
   }
 
-instance CmbDuration (ShakeCfg e) Millisecond where
+instance CmbDuration (ShakeCfg s e) Millisecond where
   duration dur = def {
     _shcTransformCfg = duration dur
   }
 
-instance CmbOnFinished (ShakeCfg e) e where
-  onFinished fn = def {
-    _shcTransformCfg = onFinished fn
+instance WidgetEvent e => CmbOnFinished (ShakeCfg s e) e where
+  onFinished handler = def {
+    _shcTransformCfg = onFinished handler
+  }
+
+instance CmbOnFinishedReq (ShakeCfg s e) s e where
+  onFinishedReq req = def {
+    _shcTransformCfg = onFinishedReq req
   }
 
 -- | Shake horizontally.
-shakeH :: ShakeCfg e
+shakeH :: ShakeCfg s e
 shakeH = def { _shcDirection = Just ShakeH }
 
 -- | Shake vertically.
-shakeV :: ShakeCfg e
+shakeV :: ShakeCfg s e
 shakeV = def { _shcDirection = Just ShakeV }
 
 -- | Shake by rotating.
-shakeR :: ShakeCfg e
+shakeR :: ShakeCfg s e
 shakeR = def { _shcDirection = Just ShakeR }
 
 -- | Shake by scaling.
-shakeS :: ShakeCfg e
+shakeS :: ShakeCfg s e
 shakeS = def { _shcDirection = Just ShakeS }
 
 -- | Amplitude of the animation. Defaults to 1.
-shakeAmplitude :: Double -> ShakeCfg e
+shakeAmplitude :: Double -> ShakeCfg s e
 shakeAmplitude amp = def { _shcAmplitude = Just amp }
 
 -- | Frequency of the animation. Defaults to 2.
-shakeFrequency :: Int -> ShakeCfg e
+shakeFrequency :: Int -> ShakeCfg s e
 shakeFrequency freq = def { _shcFrequency = Just freq }
 
 -- | Shakes a widget.
@@ -133,7 +139,7 @@ animShake managed = animShake_ def managed
 -- | Shakes a widget. Accepts config.
 animShake_
   :: WidgetEvent e
-  => [ShakeCfg e]    -- ^ The config options.
+  => [ShakeCfg s e]    -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animShake_ configs managed = node where

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -15,6 +15,7 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Slide (
   -- * Configuration

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -12,11 +12,7 @@ Messages:
 
 - Accepts a 'AnimationMsg', used to control the state of the animation.
 -}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Slide (
   -- * Configuration
@@ -33,18 +29,13 @@ module Monomer.Widgets.Animation.Slide (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (^.), (.~))
-import Control.Monad (when)
+import Control.Lens ((&), (.~))
 import Data.Default
 import Data.Maybe
-import Data.Typeable (cast)
-import GHC.Generics
-
-import qualified Data.Sequence as Seq
 
 import Monomer.Helper
 import Monomer.Widgets.Container
-import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Animation.Transform
 
 import qualified Monomer.Lens as L
 
@@ -65,25 +56,19 @@ Configuration options for slide:
 -}
 data SlideCfg e = SlideCfg {
   _slcDirection :: Maybe SlideDirection,
-  _slcAutoStart :: Maybe Bool,
-  _slcDuration :: Maybe Millisecond,
-  _slcOnFinished :: [e]
+  _slcTransformCfg :: TransformCfg e
 } deriving (Eq, Show)
 
 instance Default (SlideCfg e) where
   def = SlideCfg {
     _slcDirection = Nothing,
-    _slcAutoStart = Nothing,
-    _slcDuration = Nothing,
-    _slcOnFinished = []
+    _slcTransformCfg = def
   }
 
 instance Semigroup (SlideCfg e) where
   (<>) fc1 fc2 = SlideCfg {
     _slcDirection = _slcDirection fc2 <|> _slcDirection fc1,
-    _slcAutoStart = _slcAutoStart fc2 <|> _slcAutoStart fc1,
-    _slcDuration = _slcDuration fc2 <|> _slcDuration fc1,
-    _slcOnFinished = _slcOnFinished fc1 <> _slcOnFinished fc2
+    _slcTransformCfg = _slcTransformCfg fc1 <> _slcTransformCfg fc2
   }
 
 instance Monoid (SlideCfg e) where
@@ -91,17 +76,17 @@ instance Monoid (SlideCfg e) where
 
 instance CmbAutoStart (SlideCfg e) where
   autoStart_ start = def {
-    _slcAutoStart = Just start
+    _slcTransformCfg = autoStart_ start
   }
 
 instance CmbDuration (SlideCfg e) Millisecond where
   duration dur = def {
-    _slcDuration = Just dur
+    _slcTransformCfg = duration dur
   }
 
 instance CmbOnFinished (SlideCfg e) e where
   onFinished fn = def {
-    _slcOnFinished = [fn]
+    _slcTransformCfg = onFinished fn
   }
 
 -- | Slide from/to left.
@@ -120,17 +105,6 @@ slideTop = def { _slcDirection = Just SlideUp }
 slideBottom :: SlideCfg e
 slideBottom = def { _slcDirection = Just SlideDown }
 
-data SlideState = SlideState {
-  _slsRunning :: Bool,
-  _slsStartTs :: Millisecond
-} deriving (Eq, Show, Generic)
-
-instance Default SlideState where
-  def = SlideState {
-    _slsRunning = False,
-    _slsStartTs = 0
-  }
-
 -- | Animates a widget from the left to fully visible.
 animSlideIn
   :: WidgetEvent e
@@ -145,9 +119,8 @@ animSlideIn_
   => [SlideCfg e]    -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
-animSlideIn_ configs managed = makeNode "animSlideIn" widget managed where
-  config = mconcat configs
-  widget = makeSlide True config def
+animSlideIn_ configs managed = makeNode configs managed True
+  & L.info . L.widgetType .~ "animSlideIn"
 
 -- | Animates a widget to the left from visible to not visible.
 animSlideOut
@@ -163,93 +136,31 @@ animSlideOut_
   => [SlideCfg e]    -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
-animSlideOut_ configs managed = makeNode "animSlideOut" widget managed where
-  config = mconcat configs
-  widget = makeSlide False config def
+animSlideOut_ configs managed = makeNode configs managed False
+  & L.info . L.widgetType .~ "animSlideOut"
 
 makeNode
-  :: WidgetEvent e => WidgetType -> Widget s e -> WidgetNode s e -> WidgetNode s e
-makeNode wType widget managedWidget = defaultWidgetNode wType widget
-  & L.info . L.focusable .~ False
-  & L.children .~ Seq.singleton managedWidget
-
-makeSlide :: WidgetEvent e => Bool -> SlideCfg e -> SlideState -> Widget s e
-makeSlide isSlideIn config state = widget where
-  widget = createContainer state def {
-    containerUseScissor = True,
-    containerInit = init,
-    containerMerge = merge,
-    containerHandleMessage = handleMessage,
-    containerRender = render,
-    containerRenderAfter = renderPost
-  }
-
-  SlideState running start = state
-  autoStart = fromMaybe False (_slcAutoStart config)
-  duration = fromMaybe 500 (_slcDuration config)
-  period = 20
-  steps = fromIntegral $ duration `div` period
-
-  finishedReq node ts = delayedMessage node (AnimationFinished ts) duration
-  renderReq wenv node = req where
-    widgetId = node ^. L.info . L.widgetId
-    req = RenderEvery widgetId period (Just steps)
-
-  init wenv node = result where
-    ts = wenv ^. L.timestamp
-    newNode = node
-      & L.widget .~ makeSlide isSlideIn config (SlideState True ts)
-    result
-      | autoStart = resultReqs newNode [finishedReq node ts, renderReq wenv node]
-      | otherwise = resultNode node
-
-  merge wenv node oldNode oldState = resultNode newNode where
-    newNode = node
-      & L.widget .~ makeSlide isSlideIn config oldState
-
-  handleMessage wenv node target message = result where
-    result = cast message >>= Just . handleAnimateMsg wenv node
-
-  handleAnimateMsg wenv node msg = result where
-    widgetId = node ^. L.info . L.widgetId
-    ts = wenv ^. L.timestamp
-    startState = SlideState True ts
-    startReqs = [finishedReq node ts, renderReq wenv node]
-
-    newNode newState = node
-      & L.widget .~ makeSlide isSlideIn config newState
-    result = case msg of
-      AnimationStart -> resultReqs (newNode startState) startReqs
-      AnimationStop -> resultReqs (newNode def) [RenderStop widgetId]
-      AnimationFinished ts'
-        | isRelevant -> resultEvts node (_slcOnFinished config)
-        | otherwise -> resultNode node
-        where isRelevant = _slsRunning state && ts' == _slsStartTs state
-
-  render wenv node renderer = do
-    saveContext renderer
-    when running $
-      setTranslation renderer (Point offsetX offsetY)
-    where
-      viewport = node ^. L.info . L.viewport
-      ts = wenv ^. L.timestamp
-      dir = fromMaybe SlideLeft (_slcDirection config)
-
-      bwdStep = clamp 0 1 $ fromIntegral (ts - start) / fromIntegral duration
-      fwdStep = 1 - bwdStep
-
-      offsetX
-        | dir == SlideLeft && isSlideIn = -1 * fwdStep * viewport ^. L.w
-        | dir == SlideLeft = -1 * bwdStep * viewport ^. L.w
-        | dir == SlideRight && isSlideIn = fwdStep * viewport ^. L.w
-        | dir == SlideRight = bwdStep * viewport ^. L.w
-        | otherwise = 0
-      offsetY
-        | dir == SlideUp && isSlideIn = -1 * fwdStep * viewport ^. L.h
-        | dir == SlideUp = -1 * bwdStep * viewport ^. L.h
-        | dir == SlideDown && isSlideIn = fwdStep * viewport ^. L.h
-        | dir == SlideDown = bwdStep * viewport ^. L.h
-        | otherwise = 0
-
-  renderPost wenv node renderer = do
-    restoreContext renderer
+  :: WidgetEvent e
+  => [SlideCfg e]
+  -> WidgetNode s e
+  -> Bool
+  -> WidgetNode s e
+makeNode configs managed isSlideIn = node where
+  node = animTransform_ [_slcTransformCfg] f managed
+  f t vp = [animTranslation $ Point (fx t vp) (fy t vp)]
+  fx t (Rect _ _ w _) = case dir of
+    SlideLeft -> -1*(step t)*w
+    SlideRight -> (step t)*w
+    _ -> 0
+  fy t (Rect _ _ _ h) = case dir of
+    SlideUp -> -1*(step t)*h
+    SlideDown -> (step t)*h
+    _ -> 0
+  step t = if isSlideIn
+    then 1-(fwdStep t)
+    else fwdStep t
+  fwdStep t = clamp 0 1 $ t/(fromIntegral dur)
+  dir = fromMaybe SlideLeft _slcDirection
+  dur = fromMaybe 500 _tfcDuration
+  TransformCfg{..} = _slcTransformCfg
+  SlideCfg{..} = mconcat configs

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -54,57 +54,63 @@ Configuration options for slide:
 - 'autoStart': whether the first time the widget is added, animation should run.
 - 'duration': how long the animation lasts in ms.
 - 'onFinished': event to raise when animation is complete.
+- 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 - Individual combinators for direction.
 -}
-data SlideCfg e = SlideCfg {
+data SlideCfg s e = SlideCfg {
   _slcDirection :: Maybe SlideDirection,
-  _slcTransformCfg :: TransformCfg e
+  _slcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 
-instance Default (SlideCfg e) where
+instance Default (SlideCfg s e) where
   def = SlideCfg {
     _slcDirection = Nothing,
     _slcTransformCfg = def
   }
 
-instance Semigroup (SlideCfg e) where
+instance Semigroup (SlideCfg s e) where
   (<>) fc1 fc2 = SlideCfg {
     _slcDirection = _slcDirection fc2 <|> _slcDirection fc1,
     _slcTransformCfg = _slcTransformCfg fc1 <> _slcTransformCfg fc2
   }
 
-instance Monoid (SlideCfg e) where
+instance Monoid (SlideCfg s e) where
   mempty = def
 
-instance CmbAutoStart (SlideCfg e) where
+instance CmbAutoStart (SlideCfg s e) where
   autoStart_ start = def {
     _slcTransformCfg = autoStart_ start
   }
 
-instance CmbDuration (SlideCfg e) Millisecond where
+instance CmbDuration (SlideCfg s e) Millisecond where
   duration dur = def {
     _slcTransformCfg = duration dur
   }
 
-instance CmbOnFinished (SlideCfg e) e where
-  onFinished fn = def {
-    _slcTransformCfg = onFinished fn
+instance WidgetEvent e => CmbOnFinished (SlideCfg s e) e where
+  onFinished handler = def {
+    _slcTransformCfg = onFinished handler
+  }
+
+instance CmbOnFinishedReq (SlideCfg s e) s e where
+  onFinishedReq req = def {
+    _slcTransformCfg = onFinishedReq req
   }
 
 -- | Slide from/to left.
-slideLeft :: SlideCfg e
+slideLeft :: SlideCfg s e
 slideLeft = def { _slcDirection = Just SlideLeft }
 
 -- | Slide from/to right.
-slideRight :: SlideCfg e
+slideRight :: SlideCfg s e
 slideRight = def { _slcDirection = Just SlideRight }
 
 -- | Slide from/to top.
-slideTop :: SlideCfg e
+slideTop :: SlideCfg s e
 slideTop = def { _slcDirection = Just SlideUp }
 
 -- | Slide from/to bottom.
-slideBottom :: SlideCfg e
+slideBottom :: SlideCfg s e
 slideBottom = def { _slcDirection = Just SlideDown }
 
 -- | Animates a widget from the left to fully visible.
@@ -118,7 +124,7 @@ animSlideIn managed = animSlideIn_ def managed
 --   to left). Accepts config.
 animSlideIn_
   :: WidgetEvent e
-  => [SlideCfg e]    -- ^ The config options.
+  => [SlideCfg s e]    -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animSlideIn_ configs managed = makeNode configs managed True
@@ -135,7 +141,7 @@ animSlideOut managed = animSlideOut_ def managed
 --   visible (defaults to left). Accepts config.
 animSlideOut_
   :: WidgetEvent e
-  => [SlideCfg e]    -- ^ The config options.
+  => [SlideCfg s e]    -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animSlideOut_ configs managed = makeNode configs managed False
@@ -143,7 +149,7 @@ animSlideOut_ configs managed = makeNode configs managed False
 
 makeNode
   :: WidgetEvent e
-  => [SlideCfg e]
+  => [SlideCfg s e]
   -> WidgetNode s e
   -> Bool
   -> WidgetNode s e

--- a/src/Monomer/Widgets/Animation/Slide.hs
+++ b/src/Monomer/Widgets/Animation/Slide.hs
@@ -12,6 +12,8 @@ Messages:
 
 - Accepts a 'AnimationMsg', used to control the state of the animation.
 -}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Slide (

--- a/src/Monomer/Widgets/Animation/Transform.hs
+++ b/src/Monomer/Widgets/Animation/Transform.hs
@@ -12,6 +12,31 @@ Acts as a base for most animation widgets.
 Messages:
 
 - Accepts an 'AnimationMsg', used to control the state of the animation.
+
+@
+transform t (Rect x y w h) =
+  [ animTranslation $ Point tx ty
+  , animScale $ Point sx sy
+  ]
+
+animTransform transform managed
+@
+
+With configuration options:
+
+@
+transform t (Rect x y w h) =
+  [ animTranslation $ Point tx ty
+  , animScale $ Point sx sy
+  ]
+
+animTransform_ [duration 2000, autoStart] transform managed
+@
+
+For usage examples, see:
+
+- "Monomer.Widgets.Animation.Shake"
+- "Monomer.Widgets.Animation.Zoom"
 -}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Monomer/Widgets/Animation/Transform.hs
+++ b/src/Monomer/Widgets/Animation/Transform.hs
@@ -1,0 +1,274 @@
+{-|
+Module      : Monomer.Widgets.Animation.Transform
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Transform animation widget. Wraps a child widget whose content will be animated.
+Acts as a base for most animation widgets.
+
+Messages:
+
+- Accepts an 'AnimationMsg', used to control the state of the animation.
+-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
+
+module Monomer.Widgets.Animation.Transform (
+  -- * Configuration
+  TransformCfg(..),
+  -- * Render transformations
+  RenderTransform,
+  animTranslation,
+  animScale,
+  animRotation,
+  animGlobalAlpha,
+  animScissor,
+  -- * Constructors
+  animTransform,
+  animTransform_
+) where
+
+import Control.Applicative ((<|>))
+import Control.Lens ((&), (^.), (.~))
+import Control.Monad (when)
+import Data.Default
+import Data.Maybe
+import Data.Typeable (cast)
+import GHC.Generics
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Helper
+import Monomer.Widgets.Container
+import Monomer.Widgets.Animation.Types
+
+import qualified Monomer.Lens as L
+
+{-|
+Configuration options for transform:
+
+- 'autoStart': whether the first time the widget is added, animation should run.
+- 'duration': how long the animation lasts in ms.
+- 'onFinished': event to raise when animation is complete.
+-}
+data TransformCfg e = TransformCfg {
+  _tfcAutoStart :: Maybe Bool,
+  _tfcDuration :: Maybe Millisecond,
+  _tfcOnFinished :: [e]
+} deriving (Eq, Show)
+
+instance Default (TransformCfg e) where
+  def = TransformCfg {
+    _tfcAutoStart = Nothing,
+    _tfcDuration = Nothing,
+    _tfcOnFinished = []
+  }
+
+instance Semigroup (TransformCfg e) where
+  (<>) tc1 tc2 = TransformCfg {
+    _tfcAutoStart = _tfcAutoStart tc2 <|> _tfcAutoStart tc1,
+    _tfcDuration = _tfcDuration tc2 <|> _tfcDuration tc1,
+    _tfcOnFinished = _tfcOnFinished tc1 <> _tfcOnFinished tc2
+  }
+
+instance Monoid (TransformCfg e) where
+  mempty = def
+
+instance CmbAutoStart (TransformCfg e) where
+  autoStart_ start = def {
+    _tfcAutoStart = Just start
+  }
+
+instance CmbDuration (TransformCfg e) Millisecond where
+  duration dur = def {
+    _tfcDuration = Just dur
+  }
+
+instance CmbOnFinished (TransformCfg e) e where
+  onFinished fn = def {
+    _tfcOnFinished = [fn]
+  }
+
+data TransformState = TransformState {
+  _tfsRunning :: Bool,
+  _tfsStartTs :: Millisecond
+} deriving (Eq, Show, Generic)
+
+instance Default TransformState where
+  def = TransformState {
+    _tfsRunning = False,
+    _tfsStartTs = 0
+  }
+
+{-|
+Possible render transformations:
+
+- 'animTranslation': translates by the given offset.
+- 'animScale': scales by the given size.
+- 'animRotation': rotates by the given angle.
+- 'animGlobalAlpha': applies the given alpha.
+- 'animScissor': scissors to the given viewport.
+-}
+data RenderTransform = RenderTransform {
+  _rtTranslation :: Maybe Point,
+  _rtScale :: Maybe Point,
+  _rtRotation :: Maybe Double,
+  _rtGlobalAlpha :: Maybe Double,
+  _rtScissor :: Maybe Rect
+}
+
+instance Default RenderTransform where
+  def = RenderTransform {
+    _rtTranslation = Nothing,
+    _rtScale = Nothing,
+    _rtRotation = Nothing,
+    _rtGlobalAlpha = Nothing,
+    _rtScissor = Nothing
+  }
+
+instance Semigroup RenderTransform where
+  (<>) rt1 rt2 = RenderTransform {
+    _rtTranslation = _rtTranslation rt2 <|> _rtTranslation rt1,
+    _rtScale = _rtScale rt2 <|> _rtScale rt1,
+    _rtRotation = _rtRotation rt2 <|> _rtRotation rt1,
+    _rtGlobalAlpha = _rtGlobalAlpha rt2 <|> _rtGlobalAlpha rt1,
+    _rtScissor = _rtScissor rt2 <|> _rtScissor rt1
+  }
+
+instance Monoid RenderTransform where
+  mempty = def
+
+-- | Translate by the given offset.
+animTranslation :: Point -> RenderTransform
+animTranslation p = def { _rtTranslation = Just p }
+
+-- | Scale by the given size.
+animScale :: Point -> RenderTransform
+animScale p = def { _rtScale = Just p }
+
+-- | Rotate by the given angle.
+animRotation :: Double -> RenderTransform
+animRotation r = def { _rtRotation = Just r }
+
+-- | Apply the given alpha.
+animGlobalAlpha :: Double -> RenderTransform
+animGlobalAlpha a = def { _rtGlobalAlpha = Just a }
+
+-- | Scissor to the given viewport.
+animScissor :: Rect -> RenderTransform
+animScissor vp = def { _rtScissor = Just vp }
+
+type Transformer = (Double -> Rect -> [RenderTransform])
+
+-- | Animates a widget through translation, scaling, rotation,
+--   transparency and scissor.
+animTransform
+  :: WidgetEvent e
+  => Transformer     -- ^ Transformations from time (in ms) and viewport.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animTransform f managed = animTransform_ def f managed
+
+-- | Animates a widget through translation, scaling, rotation,
+--   transparency and scissor. Accepts config.
+animTransform_
+  :: WidgetEvent e
+  => [TransformCfg e]  -- ^ The config options.
+  -> Transformer       -- ^ Transformations from time (in ms) and viewport.
+  -> WidgetNode s e    -- ^ The child node.
+  -> WidgetNode s e    -- ^ The created animation container.
+animTransform_ configs f managed = node where
+  node = defaultWidgetNode widgetType widget
+    & L.info . L.focusable .~ False
+    & L.children .~ Seq.singleton managed
+  widgetType = WidgetType "animTransform"
+  widget = makeTransform f config def
+  config = mconcat configs
+
+makeTransform
+  :: WidgetEvent e
+  => Transformer
+  -> TransformCfg e
+  -> TransformState
+  -> Widget s e
+makeTransform f config state = widget where
+  widget = createContainer state def {
+    containerInit = init,
+    containerMerge = merge,
+    containerHandleMessage = handleMessage,
+    containerRender = render,
+    containerRenderAfter = renderPost
+  }
+
+  TransformCfg{..} = config
+  TransformState{..} = state
+  autoStart = fromMaybe False _tfcAutoStart
+  duration = fromMaybe 500 _tfcDuration
+  period = 20
+  steps = fromIntegral $ duration `div` period
+
+  finishedReq node ts = delayedMessage node (AnimationFinished ts) duration
+  renderReq wenv node = req where
+    widgetId = node ^. L.info . L.widgetId
+    req = RenderEvery widgetId period (Just steps)
+
+  init wenv node = result where
+    ts = wenv ^. L.timestamp
+    newNode = node
+      & L.widget .~ makeTransform f config (TransformState True ts)
+    result
+      | autoStart = resultReqs newNode [finishedReq node ts, renderReq wenv node]
+      | otherwise = resultNode node
+
+  merge wenv node oldNode oldState = resultNode newNode where
+    newNode = node
+      & L.widget .~ makeTransform f config oldState
+
+  handleMessage wenv node target message = result where
+    result = cast message >>= Just . handleAnimateMsg wenv node
+
+  handleAnimateMsg wenv node msg = result where
+    widgetId = node ^. L.info . L.widgetId
+    ts = wenv ^. L.timestamp
+    startState = TransformState True ts
+    startReqs = [finishedReq node ts, renderReq wenv node]
+
+    newNode newState = node
+      & L.widget .~ makeTransform f config newState
+    result = case msg of
+      AnimationStart -> resultReqs (newNode startState) startReqs
+      AnimationStop -> resultReqs (newNode def) [RenderStop widgetId]
+      AnimationFinished ts'
+        | isRelevant -> resultEvts node _tfcOnFinished
+        | otherwise -> resultNode node
+        where isRelevant = _tfsRunning && ts' == _tfsStartTs
+
+  render wenv node renderer = do
+    saveContext renderer
+    when _tfsRunning $ do
+      intersectScissor renderer scissorViewport
+      setTranslation renderer $ Point (x+w/2) (y+h/2)
+      setRotation renderer rotation
+      setTranslation renderer $ Point (-x-w/2) (-y-h/2)
+      setTranslation renderer $ Point (tx+x*(1-sx)) (ty+y*(1-sy))
+      setScale renderer scale
+      setGlobalAlpha renderer alpha
+    where
+      vp@(Rect x y w h) = node ^. L.info . L.viewport
+      t = clamp 0 duration $ (wenv ^. L.timestamp) - _tfsStartTs
+      RenderTransform{..} = mconcat $ f (fromIntegral t) vp
+      Point tx ty = fromMaybe (Point 0 0) _rtTranslation
+      scale@(Point sx sy) = fromMaybe (Point 1 1) _rtScale
+      rotation = fromMaybe 0 _rtRotation
+      alpha = fromMaybe 1 _rtGlobalAlpha
+      scissorViewport = fromMaybe vp _rtScissor
+
+  renderPost wenv node renderer = do
+    restoreContext renderer

--- a/src/Monomer/Widgets/Animation/Wipe.hs
+++ b/src/Monomer/Widgets/Animation/Wipe.hs
@@ -1,0 +1,187 @@
+{-|
+Module      : Monomer.Widgets.Animation.Wipe
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Wipe animation widget. Wraps a child widget whose content will be animated.
+
+Messages:
+
+- Accepts a 'AnimationMsg', used to control the state of the animation.
+-}
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Monomer.Widgets.Animation.Wipe (
+  -- * Configuration
+  WipeCfg,
+  wipeLeft,
+  wipeRight,
+  wipeTop,
+  wipeBottom,
+  wipeDoorH,
+  wipeDoorV,
+  wipeRect,
+  -- * Constructors
+  animWipeIn,
+  animWipeIn_,
+  animWipeOut,
+  animWipeOut_
+) where
+
+import Control.Applicative ((<|>))
+import Control.Lens ((&), (.~))
+import Data.Default
+import Data.Maybe
+
+import Monomer.Helper
+import Monomer.Widgets.Container
+import Monomer.Widgets.Animation.Transform
+
+import qualified Monomer.Lens as L
+
+data WipeDirection
+  = WipeLeft
+  | WipeRight
+  | WipeTop
+  | WipeBottom
+  | WipeDoorH
+  | WipeDoorV
+  | WipeRect
+  deriving (Eq, Show)
+
+{-|
+Configuration options for wipe:
+
+- 'autoStart': whether the first time the widget is added, animation should run.
+- 'duration': how long the animation lasts in ms.
+- 'onFinished': event to raise when animation is complete.
+- Individual combinators for direction.
+-}
+data WipeCfg e = WipeCfg {
+  _wpcDirection :: Maybe WipeDirection,
+  _wpcTransformCfg :: TransformCfg e
+} deriving (Eq, Show)
+
+instance Default (WipeCfg e) where
+  def = WipeCfg {
+    _wpcDirection = Nothing,
+    _wpcTransformCfg = def
+  }
+
+instance Semigroup (WipeCfg e) where
+  (<>) wc1 wc2 = WipeCfg {
+    _wpcDirection = _wpcDirection wc2 <|> _wpcDirection wc1,
+    _wpcTransformCfg = _wpcTransformCfg wc1 <> _wpcTransformCfg wc2
+  }
+
+instance Monoid (WipeCfg e) where
+  mempty = def
+
+instance CmbAutoStart (WipeCfg e) where
+  autoStart_ start = def {
+    _wpcTransformCfg = autoStart_ start
+  }
+
+instance CmbDuration (WipeCfg e) Millisecond where
+  duration dur = def {
+    _wpcTransformCfg = duration dur
+  }
+
+instance CmbOnFinished (WipeCfg e) e where
+  onFinished fn = def {
+    _wpcTransformCfg = onFinished fn
+  }
+
+-- | Wipe from/to left.
+wipeLeft :: WipeCfg e
+wipeLeft = def { _wpcDirection = Just WipeLeft }
+
+-- | Wipe from/to right.
+wipeRight :: WipeCfg e
+wipeRight = def { _wpcDirection = Just WipeRight }
+
+-- | Wipe from/to top.
+wipeTop :: WipeCfg e
+wipeTop = def { _wpcDirection = Just WipeTop }
+
+-- | Wipe from/to bottom.
+wipeBottom :: WipeCfg e
+wipeBottom = def { _wpcDirection = Just WipeBottom }
+
+-- | Wipe horizontally in a door shape.
+wipeDoorH :: WipeCfg e
+wipeDoorH = def { _wpcDirection = Just WipeDoorH }
+
+-- | Wipe vertically in a door shape.
+wipeDoorV :: WipeCfg e
+wipeDoorV = def { _wpcDirection = Just WipeDoorV }
+
+-- | Wipe in a rectangle shape.
+wipeRect :: WipeCfg e
+wipeRect = def { _wpcDirection = Just WipeRect }
+
+-- | Animates a widget from the left to fully visible.
+animWipeIn
+  :: WidgetEvent e
+  => WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animWipeIn managed = animWipeIn_ def managed
+
+-- | Animates a widget from the provided direction to fully visible (defaults
+--   to left). Accepts config.
+animWipeIn_
+  :: WidgetEvent e
+  => [WipeCfg e]     -- ^ The config options.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animWipeIn_ configs managed = makeNode configs managed True
+  & L.info . L.widgetType .~ "animWipeIn"
+
+-- | Animates a widget to the left from visible to not visible.
+animWipeOut
+  :: WidgetEvent e
+  => WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animWipeOut managed = animWipeOut_ def managed
+
+-- | Animates a widget to the provided direction from visible to not
+--   visible (defaults to left). Accepts config.
+animWipeOut_
+  :: WidgetEvent e
+  => [WipeCfg e]     -- ^ The config options.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animWipeOut_ configs managed = makeNode configs managed False
+  & L.info . L.widgetType .~ "animWipeOut"
+
+makeNode
+  :: WidgetEvent e
+  => [WipeCfg e]
+  -> WidgetNode s e
+  -> Bool
+  -> WidgetNode s e
+makeNode configs managed isWipeIn = node where
+  node = animTransform_ [_wpcTransformCfg] f managed
+  f t (Rect x y w h) = [animScissor vp] where
+    vp = case dir of
+      WipeLeft -> Rect x y dw h
+      WipeRight -> Rect (x+(1-(step t))*w) y dw h
+      WipeTop -> Rect x y w dh
+      WipeBottom -> Rect x (y+(1-(step t))*h) w dh
+      WipeDoorH -> Rect dx y dw h
+      WipeDoorV -> Rect x dy w dh
+      WipeRect -> Rect dx dy dw dh
+    (dx, dy) = (x+(1-(step t))*w/2, y+(1-(step t))*h/2)
+    (dw, dh) = ((step t)*w, (step t)*h)
+  step t = if isWipeIn
+    then fwdStep t
+    else 1-(fwdStep t)
+  fwdStep t = clamp 0 1 $ t/(fromIntegral dur)
+  dir = fromMaybe WipeLeft _wpcDirection
+  dur = fromMaybe 500 _tfcDuration
+  TransformCfg{..} = _wpcTransformCfg
+  WipeCfg{..} = mconcat configs

--- a/src/Monomer/Widgets/Animation/Wipe.hs
+++ b/src/Monomer/Widgets/Animation/Wipe.hs
@@ -12,7 +12,8 @@ Messages:
 
 - Accepts a 'AnimationMsg', used to control the state of the animation.
 -}
-
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Wipe (

--- a/src/Monomer/Widgets/Animation/Wipe.hs
+++ b/src/Monomer/Widgets/Animation/Wipe.hs
@@ -15,6 +15,7 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Wipe (
   -- * Configuration

--- a/src/Monomer/Widgets/Animation/Wipe.hs
+++ b/src/Monomer/Widgets/Animation/Wipe.hs
@@ -60,69 +60,75 @@ Configuration options for wipe:
 - 'autoStart': whether the first time the widget is added, animation should run.
 - 'duration': how long the animation lasts in ms.
 - 'onFinished': event to raise when animation is complete.
+- 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 - Individual combinators for direction.
 -}
-data WipeCfg e = WipeCfg {
+data WipeCfg s e = WipeCfg {
   _wpcDirection :: Maybe WipeDirection,
-  _wpcTransformCfg :: TransformCfg e
+  _wpcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 
-instance Default (WipeCfg e) where
+instance Default (WipeCfg s e) where
   def = WipeCfg {
     _wpcDirection = Nothing,
     _wpcTransformCfg = def
   }
 
-instance Semigroup (WipeCfg e) where
+instance Semigroup (WipeCfg s e) where
   (<>) wc1 wc2 = WipeCfg {
     _wpcDirection = _wpcDirection wc2 <|> _wpcDirection wc1,
     _wpcTransformCfg = _wpcTransformCfg wc1 <> _wpcTransformCfg wc2
   }
 
-instance Monoid (WipeCfg e) where
+instance Monoid (WipeCfg s e) where
   mempty = def
 
-instance CmbAutoStart (WipeCfg e) where
+instance CmbAutoStart (WipeCfg s e) where
   autoStart_ start = def {
     _wpcTransformCfg = autoStart_ start
   }
 
-instance CmbDuration (WipeCfg e) Millisecond where
+instance CmbDuration (WipeCfg s e) Millisecond where
   duration dur = def {
     _wpcTransformCfg = duration dur
   }
 
-instance CmbOnFinished (WipeCfg e) e where
-  onFinished fn = def {
-    _wpcTransformCfg = onFinished fn
+instance WidgetEvent e => CmbOnFinished (WipeCfg s e) e where
+  onFinished handler = def {
+    _wpcTransformCfg = onFinished handler
+  }
+
+instance CmbOnFinishedReq (WipeCfg s e) s e where
+  onFinishedReq req = def {
+    _wpcTransformCfg = onFinishedReq req
   }
 
 -- | Wipe from/to left.
-wipeLeft :: WipeCfg e
+wipeLeft :: WipeCfg s e
 wipeLeft = def { _wpcDirection = Just WipeLeft }
 
 -- | Wipe from/to right.
-wipeRight :: WipeCfg e
+wipeRight :: WipeCfg s e
 wipeRight = def { _wpcDirection = Just WipeRight }
 
 -- | Wipe from/to top.
-wipeTop :: WipeCfg e
+wipeTop :: WipeCfg s e
 wipeTop = def { _wpcDirection = Just WipeTop }
 
 -- | Wipe from/to bottom.
-wipeBottom :: WipeCfg e
+wipeBottom :: WipeCfg s e
 wipeBottom = def { _wpcDirection = Just WipeBottom }
 
 -- | Wipe horizontally in a door shape.
-wipeDoorH :: WipeCfg e
+wipeDoorH :: WipeCfg s e
 wipeDoorH = def { _wpcDirection = Just WipeDoorH }
 
 -- | Wipe vertically in a door shape.
-wipeDoorV :: WipeCfg e
+wipeDoorV :: WipeCfg s e
 wipeDoorV = def { _wpcDirection = Just WipeDoorV }
 
 -- | Wipe in a rectangle shape.
-wipeRect :: WipeCfg e
+wipeRect :: WipeCfg s e
 wipeRect = def { _wpcDirection = Just WipeRect }
 
 -- | Animates a widget from the left to fully visible.
@@ -136,7 +142,7 @@ animWipeIn managed = animWipeIn_ def managed
 --   to left). Accepts config.
 animWipeIn_
   :: WidgetEvent e
-  => [WipeCfg e]     -- ^ The config options.
+  => [WipeCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animWipeIn_ configs managed = makeNode configs managed True
@@ -153,7 +159,7 @@ animWipeOut managed = animWipeOut_ def managed
 --   visible (defaults to left). Accepts config.
 animWipeOut_
   :: WidgetEvent e
-  => [WipeCfg e]     -- ^ The config options.
+  => [WipeCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animWipeOut_ configs managed = makeNode configs managed False
@@ -161,7 +167,7 @@ animWipeOut_ configs managed = makeNode configs managed False
 
 makeNode
   :: WidgetEvent e
-  => [WipeCfg e]
+  => [WipeCfg s e]
   -> WidgetNode s e
   -> Bool
   -> WidgetNode s e

--- a/src/Monomer/Widgets/Animation/Zoom.hs
+++ b/src/Monomer/Widgets/Animation/Zoom.hs
@@ -42,37 +42,43 @@ Configuration options for zoom:
 - 'autoStart': whether the first time the widget is added, animation should run.
 - 'duration': how long the animation lasts in ms.
 - 'onFinished': event to raise when animation is complete.
+- 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 -}
-data ZoomCfg e = ZoomCfg {
-  _zmcTransformCfg :: TransformCfg e
+data ZoomCfg s e = ZoomCfg {
+  _zmcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 
-instance Default (ZoomCfg e) where
+instance Default (ZoomCfg s e) where
   def = ZoomCfg {
     _zmcTransformCfg = def
   }
 
-instance Semigroup (ZoomCfg e) where
+instance Semigroup (ZoomCfg s e) where
   (<>) zc1 zc2 = ZoomCfg {
     _zmcTransformCfg = _zmcTransformCfg zc1 <> _zmcTransformCfg zc2
   }
 
-instance Monoid (ZoomCfg e) where
+instance Monoid (ZoomCfg s e) where
   mempty = def
 
-instance CmbAutoStart (ZoomCfg e) where
+instance CmbAutoStart (ZoomCfg s e) where
   autoStart_ start = def {
     _zmcTransformCfg = autoStart_ start
   }
 
-instance CmbDuration (ZoomCfg e) Millisecond where
+instance CmbDuration (ZoomCfg s e) Millisecond where
   duration dur = def {
     _zmcTransformCfg = duration dur
   }
 
-instance CmbOnFinished (ZoomCfg e) e where
-  onFinished fn = def {
-    _zmcTransformCfg = onFinished fn
+instance WidgetEvent e => CmbOnFinished (ZoomCfg s e) e where
+  onFinished handler = def {
+    _zmcTransformCfg = onFinished handler
+  }
+
+instance CmbOnFinishedReq (ZoomCfg s e) s e where
+  onFinishedReq req = def {
+    _zmcTransformCfg = onFinishedReq req
   }
 
 -- | Animates a widget to fully visible by increasing scale.
@@ -85,7 +91,7 @@ animZoomIn managed = animZoomIn_ def managed
 -- | Animates a widget to fully visible by increasing scale. Accepts config.
 animZoomIn_
   :: WidgetEvent e
-  => [ZoomCfg e]     -- ^ The config options.
+  => [ZoomCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animZoomIn_ configs managed = makeNode configs managed True
@@ -101,7 +107,7 @@ animZoomOut managed = animZoomOut_ def managed
 -- | Animates a widget to not visible by decreasing scale. Accepts config.
 animZoomOut_
   :: WidgetEvent e
-  => [ZoomCfg e]     -- ^ The config options.
+  => [ZoomCfg s e]     -- ^ The config options.
   -> WidgetNode s e  -- ^ The child node.
   -> WidgetNode s e  -- ^ The created animation container.
 animZoomOut_ configs managed = makeNode configs managed False
@@ -109,7 +115,7 @@ animZoomOut_ configs managed = makeNode configs managed False
 
 makeNode
   :: WidgetEvent e
-  => [ZoomCfg e]
+  => [ZoomCfg s e]
   -> WidgetNode s e
   -> Bool
   -> WidgetNode s e

--- a/src/Monomer/Widgets/Animation/Zoom.hs
+++ b/src/Monomer/Widgets/Animation/Zoom.hs
@@ -12,7 +12,8 @@ Messages:
 
 - Accepts a 'AnimationMsg', used to control the state of the animation.
 -}
-
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Monomer.Widgets.Animation.Zoom (

--- a/src/Monomer/Widgets/Animation/Zoom.hs
+++ b/src/Monomer/Widgets/Animation/Zoom.hs
@@ -45,7 +45,7 @@ Configuration options for zoom:
 - 'onFinished': event to raise when animation is complete.
 - 'onFinishedReq': 'WidgetRequest' to generate when animation is complete.
 -}
-data ZoomCfg s e = ZoomCfg {
+newtype ZoomCfg s e = ZoomCfg {
   _zmcTransformCfg :: TransformCfg s e
 } deriving (Eq, Show)
 

--- a/src/Monomer/Widgets/Animation/Zoom.hs
+++ b/src/Monomer/Widgets/Animation/Zoom.hs
@@ -1,0 +1,128 @@
+{-|
+Module      : Monomer.Widgets.Animation.Zoom
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Zoom animation widget. Wraps a child widget whose content will be animated.
+
+Messages:
+
+- Accepts a 'AnimationMsg', used to control the state of the animation.
+-}
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Monomer.Widgets.Animation.Zoom (
+  -- * Configuration
+  ZoomCfg,
+  -- * Constructors
+  animZoomIn,
+  animZoomIn_,
+  animZoomOut,
+  animZoomOut_
+) where
+
+import Control.Lens ((&), (.~))
+import Data.Default
+import Data.Maybe
+
+import Monomer.Helper
+import Monomer.Widgets.Container
+import Monomer.Widgets.Animation.Transform
+
+import qualified Monomer.Lens as L
+
+{-|
+Configuration options for zoom:
+
+- 'autoStart': whether the first time the widget is added, animation should run.
+- 'duration': how long the animation lasts in ms.
+- 'onFinished': event to raise when animation is complete.
+-}
+data ZoomCfg e = ZoomCfg {
+  _zmcTransformCfg :: TransformCfg e
+} deriving (Eq, Show)
+
+instance Default (ZoomCfg e) where
+  def = ZoomCfg {
+    _zmcTransformCfg = def
+  }
+
+instance Semigroup (ZoomCfg e) where
+  (<>) zc1 zc2 = ZoomCfg {
+    _zmcTransformCfg = _zmcTransformCfg zc1 <> _zmcTransformCfg zc2
+  }
+
+instance Monoid (ZoomCfg e) where
+  mempty = def
+
+instance CmbAutoStart (ZoomCfg e) where
+  autoStart_ start = def {
+    _zmcTransformCfg = autoStart_ start
+  }
+
+instance CmbDuration (ZoomCfg e) Millisecond where
+  duration dur = def {
+    _zmcTransformCfg = duration dur
+  }
+
+instance CmbOnFinished (ZoomCfg e) e where
+  onFinished fn = def {
+    _zmcTransformCfg = onFinished fn
+  }
+
+-- | Animates a widget to fully visible by increasing scale.
+animZoomIn
+  :: WidgetEvent e
+  => WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animZoomIn managed = animZoomIn_ def managed
+
+-- | Animates a widget to fully visible by increasing scale. Accepts config.
+animZoomIn_
+  :: WidgetEvent e
+  => [ZoomCfg e]     -- ^ The config options.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animZoomIn_ configs managed = makeNode configs managed True
+  & L.info . L.widgetType .~ "animZoomIn"
+
+-- | Animates a widget to not visible by decreasing scale.
+animZoomOut
+  :: WidgetEvent e
+  => WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animZoomOut managed = animZoomOut_ def managed
+
+-- | Animates a widget to not visible by decreasing scale. Accepts config.
+animZoomOut_
+  :: WidgetEvent e
+  => [ZoomCfg e]     -- ^ The config options.
+  -> WidgetNode s e  -- ^ The child node.
+  -> WidgetNode s e  -- ^ The created animation container.
+animZoomOut_ configs managed = makeNode configs managed False
+  & L.info . L.widgetType .~ "animZoomOut"
+
+makeNode
+  :: WidgetEvent e
+  => [ZoomCfg e]
+  -> WidgetNode s e
+  -> Bool
+  -> WidgetNode s e
+makeNode configs managed isZoomIn = node where
+  node = animTransform_ [_zmcTransformCfg] f managed
+  f t (Rect _ _ w h) =
+    [ animTranslation $ Point (ft t w) (ft t h)
+    , animScale $ Point (fs t) (fs t)
+    ]
+  ft t s = (1-(fs t))*s/2
+  fs t = if isZoomIn
+    then fwdStep t
+    else 1-(fwdStep t)
+  fwdStep t = clamp 0 1 $ t/(fromIntegral dur)
+  dur = fromMaybe 500 _tfcDuration
+  TransformCfg{..} = _zmcTransformCfg
+  ZoomCfg{..} = mconcat configs

--- a/src/Monomer/Widgets/Animation/Zoom.hs
+++ b/src/Monomer/Widgets/Animation/Zoom.hs
@@ -15,6 +15,7 @@ Messages:
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
 
 module Monomer.Widgets.Animation.Zoom (
   -- * Configuration

--- a/test/unit/Monomer/Widgets/Animation/ShakeSpec.hs
+++ b/test/unit/Monomer/Widgets/Animation/ShakeSpec.hs
@@ -1,0 +1,98 @@
+{-|
+Module      : Monomer.Widgets.Animation.ShakeSpec
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for Shake animation.
+-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Monomer.Widgets.Animation.ShakeSpec (spec) where
+
+import Control.Lens ((&), (^.), (.~), (?~), (^?!), _1, _3, ix)
+import Data.Default
+import Data.Text (Text)
+import Test.Hspec
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+import Monomer.Event
+import Monomer.TestUtil
+import Monomer.TestEventUtil
+import Monomer.Widgets.Animation.Shake
+import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Containers.Stack
+import Monomer.Widgets.Containers.Scroll
+import Monomer.Widgets.Singles.Label
+
+import qualified Monomer.Lens as L
+
+data TestEvt
+  = OnTestFinished
+  deriving (Eq, Show)
+
+spec :: Spec
+spec = describe "Shake" $ do
+  initWidget
+  handleMessage
+  getSizeReq
+
+initWidget :: Spec
+initWidget = describe "initWidget" $ do
+  it "should not request rendering if autoStart = False" $
+    reqs nodeNormal `shouldBe` Seq.empty
+
+  it "should request rendering if autoStart = True" $ do
+    reqs nodeAuto ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs nodeAuto ^?! ix 1 `shouldSatisfy` isRenderEvery
+
+  where
+    wenv = mockWenvEvtUnit ()
+    nodeNormal = animShake (label "Test")
+    nodeAuto = animShake_ [autoStart, duration 100] (label "Test")
+    reqs node = nodeHandleEvents_ wenv WInit [] node ^?! ix 0 . _1 . _3
+
+handleMessage :: Spec
+handleMessage = describe "handleMessage" $ do
+  it "should not request rendering if an invalid message is received" $
+    reqs ScrollReset `shouldBe` Seq.empty
+
+  it "should request rendering if AnimationStart is received" $ do
+    reqs AnimationStart ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs AnimationStart ^?! ix 1 `shouldSatisfy` isRenderEvery
+    evts AnimationStart `shouldBe` Seq.empty
+
+  it "should cancel rendering if AnimationStop is received" $ do
+    reqs AnimationStop ^?! ix 0 `shouldSatisfy` isRenderStop
+    evts AnimationStop `shouldBe` Seq.empty
+
+  it "should generate an event if AnimationFinished is received" $
+    evts (AnimationFinished 0) `shouldBe` Seq.singleton OnTestFinished
+
+  where
+    wenv = mockWenv ()
+    baseNode = animShake_ [autoStart, duration 100, onFinished OnTestFinished] (label "Test")
+    node = nodeInit wenv baseNode
+    res msg = widgetHandleMessage (node^. L.widget) wenv node rootPath msg
+    evts msg = eventsFromReqs (reqs msg)
+    reqs msg = maybe Seq.empty (^. L.requests) (res msg)
+
+getSizeReq :: Spec
+getSizeReq = describe "getSizeReq" $ do
+  it "should return same reqW as child node" $
+    tSizeReqW `shouldBe` lSizeReqW
+
+  it "should return same reqH as child node" $
+    tSizeReqH `shouldBe` lSizeReqH
+
+  where
+    wenv = mockWenvEvtUnit ()
+    lblNode = label "Test label"
+    (lSizeReqW, lSizeReqH) = nodeGetSizeReq wenv lblNode
+    (tSizeReqW, tSizeReqH) = nodeGetSizeReq wenv (animShake lblNode)

--- a/test/unit/Monomer/Widgets/Animation/TransformSpec.hs
+++ b/test/unit/Monomer/Widgets/Animation/TransformSpec.hs
@@ -1,0 +1,101 @@
+{-|
+Module      : Monomer.Widgets.Animation.TransformSpec
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for Transform animation.
+-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Monomer.Widgets.Animation.TransformSpec (spec) where
+
+import Control.Lens ((&), (^.), (.~), (?~), (^?!), _1, _3, ix)
+import Data.Default
+import Data.Text (Text)
+import Test.Hspec
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+import Monomer.Event
+import Monomer.TestUtil
+import Monomer.TestEventUtil
+import Monomer.Widgets.Animation.Transform
+import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Containers.Scroll
+import Monomer.Widgets.Containers.Stack
+import Monomer.Widgets.Singles.Label
+
+import qualified Monomer.Lens as L
+
+data TestEvt
+  = OnTestFinished
+  deriving (Eq, Show)
+
+spec :: Spec
+spec = describe "Transform" $ do
+  initWidget
+  handleMessage
+  getSizeReq
+
+initWidget :: Spec
+initWidget = describe "initWidget" $ do
+  it "should not request rendering if autoStart = False" $
+    reqs nodeNormal `shouldBe` Seq.empty
+
+  it "should request rendering if autoStart = True" $ do
+    reqs nodeAuto ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs nodeAuto ^?! ix 1 `shouldSatisfy` isRenderEvery
+
+  where
+    wenv = mockWenvEvtUnit ()
+    f _ _ = []
+    nodeNormal = animTransform f (label "Test")
+    nodeAuto = animTransform_ [autoStart, duration 100] f (label "Test")
+    reqs node = nodeHandleEvents_ wenv WInit [] node ^?! ix 0 . _1 . _3
+
+handleMessage :: Spec
+handleMessage = describe "handleMessage" $ do
+  it "should not request rendering if an invalid message is received" $
+    reqs ScrollReset `shouldBe` Seq.empty
+
+  it "should request rendering if AnimationStart is received" $ do
+    reqs AnimationStart ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs AnimationStart ^?! ix 1 `shouldSatisfy` isRenderEvery
+    evts AnimationStart `shouldBe` Seq.empty
+
+  it "should cancel rendering if AnimationStop is received" $ do
+    reqs AnimationStop ^?! ix 0 `shouldSatisfy` isRenderStop
+    evts AnimationStop `shouldBe` Seq.empty
+
+  it "should generate an event if AnimationFinished is received" $
+    evts (AnimationFinished 0) `shouldBe` Seq.singleton OnTestFinished
+
+  where
+    wenv = mockWenv ()
+    f _ _ = []
+    baseNode = animTransform_ [autoStart, duration 100, onFinished OnTestFinished] f (label "Test")
+    node = nodeInit wenv baseNode
+    res msg = widgetHandleMessage (node^. L.widget) wenv node rootPath msg
+    evts msg = eventsFromReqs (reqs msg)
+    reqs msg = maybe Seq.empty (^. L.requests) (res msg)
+
+getSizeReq :: Spec
+getSizeReq = describe "getSizeReq" $ do
+  it "should return same reqW as child node" $
+    tSizeReqW `shouldBe` lSizeReqW
+
+  it "should return same reqH as child node" $
+    tSizeReqH `shouldBe` lSizeReqH
+
+  where
+    wenv = mockWenvEvtUnit ()
+    lblNode = label "Test label"
+    f _ _ = []
+    (lSizeReqW, lSizeReqH) = nodeGetSizeReq wenv lblNode
+    (tSizeReqW, tSizeReqH) = nodeGetSizeReq wenv (animTransform f lblNode)

--- a/test/unit/Monomer/Widgets/Animation/WipeSpec.hs
+++ b/test/unit/Monomer/Widgets/Animation/WipeSpec.hs
@@ -1,0 +1,98 @@
+{-|
+Module      : Monomer.Widgets.Animation.WipeSpec
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for Wipe animation.
+-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Monomer.Widgets.Animation.WipeSpec (spec) where
+
+import Control.Lens ((&), (^.), (.~), (?~), (^?!), _1, _3, ix)
+import Data.Default
+import Data.Text (Text)
+import Test.Hspec
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+import Monomer.Event
+import Monomer.TestUtil
+import Monomer.TestEventUtil
+import Monomer.Widgets.Animation.Wipe
+import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Containers.Stack
+import Monomer.Widgets.Containers.Scroll
+import Monomer.Widgets.Singles.Label
+
+import qualified Monomer.Lens as L
+
+data TestEvt
+  = OnTestFinished
+  deriving (Eq, Show)
+
+spec :: Spec
+spec = describe "Wipe" $ do
+  initWidget
+  handleMessage
+  getSizeReq
+
+initWidget :: Spec
+initWidget = describe "initWidget" $ do
+  it "should not request rendering if autoStart = False" $
+    reqs nodeNormal `shouldBe` Seq.empty
+
+  it "should request rendering if autoStart = True" $ do
+    reqs nodeAuto ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs nodeAuto ^?! ix 1 `shouldSatisfy` isRenderEvery
+
+  where
+    wenv = mockWenvEvtUnit ()
+    nodeNormal = animWipeIn (label "Test")
+    nodeAuto = animWipeIn_ [autoStart, duration 100] (label "Test")
+    reqs node = nodeHandleEvents_ wenv WInit [] node ^?! ix 0 . _1 . _3
+
+handleMessage :: Spec
+handleMessage = describe "handleMessage" $ do
+  it "should not request rendering if an invalid message is received" $
+    reqs ScrollReset `shouldBe` Seq.empty
+
+  it "should request rendering if AnimationStart is received" $ do
+    reqs AnimationStart ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs AnimationStart ^?! ix 1 `shouldSatisfy` isRenderEvery
+    evts AnimationStart `shouldBe` Seq.empty
+
+  it "should cancel rendering if AnimationStop is received" $ do
+    reqs AnimationStop ^?! ix 0 `shouldSatisfy` isRenderStop
+    evts AnimationStop `shouldBe` Seq.empty
+
+  it "should generate an event if AnimationFinished is received" $
+    evts (AnimationFinished 0) `shouldBe` Seq.singleton OnTestFinished
+
+  where
+    wenv = mockWenv ()
+    baseNode = animWipeIn_ [autoStart, duration 100, onFinished OnTestFinished] (label "Test")
+    node = nodeInit wenv baseNode
+    res msg = widgetHandleMessage (node^. L.widget) wenv node rootPath msg
+    evts msg = eventsFromReqs (reqs msg)
+    reqs msg = maybe Seq.empty (^. L.requests) (res msg)
+
+getSizeReq :: Spec
+getSizeReq = describe "getSizeReq" $ do
+  it "should return same reqW as child node" $
+    tSizeReqW `shouldBe` lSizeReqW
+
+  it "should return same reqH as child node" $
+    tSizeReqH `shouldBe` lSizeReqH
+
+  where
+    wenv = mockWenvEvtUnit ()
+    lblNode = label "Test label"
+    (lSizeReqW, lSizeReqH) = nodeGetSizeReq wenv lblNode
+    (tSizeReqW, tSizeReqH) = nodeGetSizeReq wenv (animWipeIn lblNode)

--- a/test/unit/Monomer/Widgets/Animation/ZoomSpec.hs
+++ b/test/unit/Monomer/Widgets/Animation/ZoomSpec.hs
@@ -1,0 +1,98 @@
+{-|
+Module      : Monomer.Widgets.Animation.ZoomSpec
+Copyright   : (c) 2023 Ruslan Gadeev, Francisco Vallarino
+License     : BSD-3-Clause (see the LICENSE file)
+Maintainer  : fjvallarino@gmail.com
+Stability   : experimental
+Portability : non-portable
+
+Unit tests for Zoom animation.
+-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Monomer.Widgets.Animation.ZoomSpec (spec) where
+
+import Control.Lens ((&), (^.), (.~), (?~), (^?!), _1, _3, ix)
+import Data.Default
+import Data.Text (Text)
+import Test.Hspec
+
+import qualified Data.Sequence as Seq
+
+import Monomer.Core
+import Monomer.Core.Combinators
+import Monomer.Event
+import Monomer.TestUtil
+import Monomer.TestEventUtil
+import Monomer.Widgets.Animation.Zoom
+import Monomer.Widgets.Animation.Types
+import Monomer.Widgets.Containers.Stack
+import Monomer.Widgets.Containers.Scroll
+import Monomer.Widgets.Singles.Label
+
+import qualified Monomer.Lens as L
+
+data TestEvt
+  = OnTestFinished
+  deriving (Eq, Show)
+
+spec :: Spec
+spec = describe "Zoom" $ do
+  initWidget
+  handleMessage
+  getSizeReq
+
+initWidget :: Spec
+initWidget = describe "initWidget" $ do
+  it "should not request rendering if autoStart = False" $
+    reqs nodeNormal `shouldBe` Seq.empty
+
+  it "should request rendering if autoStart = True" $ do
+    reqs nodeAuto ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs nodeAuto ^?! ix 1 `shouldSatisfy` isRenderEvery
+
+  where
+    wenv = mockWenvEvtUnit ()
+    nodeNormal = animZoomIn (label "Test")
+    nodeAuto = animZoomIn_ [autoStart, duration 100] (label "Test")
+    reqs node = nodeHandleEvents_ wenv WInit [] node ^?! ix 0 . _1 . _3
+
+handleMessage :: Spec
+handleMessage = describe "handleMessage" $ do
+  it "should not request rendering if an invalid message is received" $
+    reqs ScrollReset `shouldBe` Seq.empty
+
+  it "should request rendering if AnimationStart is received" $ do
+    reqs AnimationStart ^?! ix 0 `shouldSatisfy` isRunTask
+    reqs AnimationStart ^?! ix 1 `shouldSatisfy` isRenderEvery
+    evts AnimationStart `shouldBe` Seq.empty
+
+  it "should cancel rendering if AnimationStop is received" $ do
+    reqs AnimationStop ^?! ix 0 `shouldSatisfy` isRenderStop
+    evts AnimationStop `shouldBe` Seq.empty
+
+  it "should generate an event if AnimationFinished is received" $
+    evts (AnimationFinished 0) `shouldBe` Seq.singleton OnTestFinished
+
+  where
+    wenv = mockWenv ()
+    baseNode = animZoomIn_ [autoStart, duration 100, onFinished OnTestFinished] (label "Test")
+    node = nodeInit wenv baseNode
+    res msg = widgetHandleMessage (node^. L.widget) wenv node rootPath msg
+    evts msg = eventsFromReqs (reqs msg)
+    reqs msg = maybe Seq.empty (^. L.requests) (res msg)
+
+getSizeReq :: Spec
+getSizeReq = describe "getSizeReq" $ do
+  it "should return same reqW as child node" $
+    tSizeReqW `shouldBe` lSizeReqW
+
+  it "should return same reqH as child node" $
+    tSizeReqH `shouldBe` lSizeReqH
+
+  where
+    wenv = mockWenvEvtUnit ()
+    lblNode = label "Test label"
+    (lSizeReqW, lSizeReqH) = nodeGetSizeReq wenv lblNode
+    (tSizeReqW, tSizeReqH) = nodeGetSizeReq wenv (animZoomIn lblNode)

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -19,6 +19,7 @@ import qualified Monomer.Widgets.ContainerSpec as ContainerSpec
 
 import qualified Monomer.Widgets.Animation.FadeSpec as AnimationFadeSpec
 import qualified Monomer.Widgets.Animation.SlideSpec as AnimationSlideSpec
+import qualified Monomer.Widgets.Animation.TransformSpec as AnimationTransformSpec
 
 import qualified Monomer.Widgets.Containers.AlertSpec as AlertSpec
 import qualified Monomer.Widgets.Containers.BoxSpec as BoxSpec
@@ -111,6 +112,7 @@ animation :: Spec
 animation = describe "Animation" $ do
   AnimationFadeSpec.spec
   AnimationSlideSpec.spec
+  AnimationTransformSpec.spec
 
 containers :: Spec
 containers = describe "Containers" $ do

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -18,6 +18,7 @@ import qualified Monomer.Widgets.CompositeSpec as CompositeSpec
 import qualified Monomer.Widgets.ContainerSpec as ContainerSpec
 
 import qualified Monomer.Widgets.Animation.FadeSpec as AnimationFadeSpec
+import qualified Monomer.Widgets.Animation.ShakeSpec as AnimationShakeSpec
 import qualified Monomer.Widgets.Animation.SlideSpec as AnimationSlideSpec
 import qualified Monomer.Widgets.Animation.TransformSpec as AnimationTransformSpec
 import qualified Monomer.Widgets.Animation.WipeSpec as AnimationWipeSpec
@@ -113,6 +114,7 @@ widgets = describe "Widgets" $ do
 animation :: Spec
 animation = describe "Animation" $ do
   AnimationFadeSpec.spec
+  AnimationShakeSpec.spec
   AnimationSlideSpec.spec
   AnimationTransformSpec.spec
   AnimationWipeSpec.spec

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -20,6 +20,7 @@ import qualified Monomer.Widgets.ContainerSpec as ContainerSpec
 import qualified Monomer.Widgets.Animation.FadeSpec as AnimationFadeSpec
 import qualified Monomer.Widgets.Animation.SlideSpec as AnimationSlideSpec
 import qualified Monomer.Widgets.Animation.TransformSpec as AnimationTransformSpec
+import qualified Monomer.Widgets.Animation.ZoomSpec as AnimationZoomSpec
 
 import qualified Monomer.Widgets.Containers.AlertSpec as AlertSpec
 import qualified Monomer.Widgets.Containers.BoxSpec as BoxSpec
@@ -113,6 +114,7 @@ animation = describe "Animation" $ do
   AnimationFadeSpec.spec
   AnimationSlideSpec.spec
   AnimationTransformSpec.spec
+  AnimationZoomSpec.spec
 
 containers :: Spec
 containers = describe "Containers" $ do

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -20,6 +20,7 @@ import qualified Monomer.Widgets.ContainerSpec as ContainerSpec
 import qualified Monomer.Widgets.Animation.FadeSpec as AnimationFadeSpec
 import qualified Monomer.Widgets.Animation.SlideSpec as AnimationSlideSpec
 import qualified Monomer.Widgets.Animation.TransformSpec as AnimationTransformSpec
+import qualified Monomer.Widgets.Animation.WipeSpec as AnimationWipeSpec
 import qualified Monomer.Widgets.Animation.ZoomSpec as AnimationZoomSpec
 
 import qualified Monomer.Widgets.Containers.AlertSpec as AlertSpec
@@ -114,6 +115,7 @@ animation = describe "Animation" $ do
   AnimationFadeSpec.spec
   AnimationSlideSpec.spec
   AnimationTransformSpec.spec
+  AnimationWipeSpec.spec
   AnimationZoomSpec.spec
 
 containers :: Spec


### PR DESCRIPTION
I noticed that Fade and Slide animation widgets code is very similar, so I created general Transform animation widget which receives function of time and viewport and allows to translate, scale, rotate, scissor and set transparency accordingly. Then I refactored Fade and Slide using the Transform widget and checked that their behavior didn't change.

Also I added Zoom, Wipe and Shake animation widgets using the Transform widget and added `onFinishedReq` combinator.

Here are Fade and Slide widgets, so you can see that they behave the same as before:

[fade.webm](https://github.com/fjvallarino/monomer/assets/26405676/945a71ac-dd28-4afc-a0de-931fca4914ae)

[slide.webm](https://github.com/fjvallarino/monomer/assets/26405676/06365467-05af-4bf3-96e8-e1fbf2495c3b)

Here are new Zoom, Wipe and Shake widgets:

[zoom.webm](https://github.com/fjvallarino/monomer/assets/26405676/35f0c9f6-0b62-41e9-891a-92c64520339b)

[wipe.webm](https://github.com/fjvallarino/monomer/assets/26405676/e9ec89f5-872b-422b-bef6-6a282330d3ff)

[shake.webm](https://github.com/fjvallarino/monomer/assets/26405676/508e9471-8795-4c73-b146-d015967d09ae)

And the Transform widget which uses multiple transformations simultaneously:

[transform.webm](https://github.com/fjvallarino/monomer/assets/26405676/3d81c2d0-76f3-4075-bf74-d18bb7483a79)
