### PR TITLE
FileDrop event added

### DIFF
--- a/monomer.cabal
+++ b/monomer.cabal
@@ -179,6 +179,7 @@ library
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -225,6 +226,7 @@ executable books
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -268,6 +270,7 @@ executable dev-test-app
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -310,6 +313,7 @@ executable generative
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -355,6 +359,7 @@ executable opengl
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -402,6 +407,7 @@ executable ticker
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -448,6 +454,7 @@ executable todo
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -499,6 +506,7 @@ executable tutorial
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
@@ -597,6 +605,7 @@ test-suite monomer-test
     , data-default >=0.5 && <0.8
     , exceptions ==0.10.*
     , extra >=1.6 && <1.9
+    , filepath ==1.4.*
     , foreign-store >=0.2 && <1.0
     , formatting >=6.0 && <8.0
     , hspec >=2.4 && <3.0

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,8 @@ dependencies:
   - transformers >= 0.5 && < 0.7
   - vector >= 0.12 && < 0.14
   - wreq >= 0.5.2 && < 0.6
+#  - filepath >= 1.4.100.1 && < 1.5
+  - filepath >= 1.4 && < 1.5
 
 flags:
   examples:

--- a/src/Monomer/Event/Types.hs
+++ b/src/Monomer/Event/Types.hs
@@ -17,6 +17,8 @@ import Data.Default
 import Data.Text (Text)
 import Data.Typeable (Typeable, cast, typeOf)
 import Data.Map.Strict (Map)
+--import System.OsPath (OsPath)
+import System.FilePath (FilePath)
 
 import qualified Data.Map.Strict as M
 
@@ -117,6 +119,9 @@ data SystemEvent
   -- | A drag action was active and the main button was released inside the
   --   current viewport.
   | Drop Point Path WidgetDragMsg
+  -- | File dragged and dropped into window.
+  -- | FileDrop OsPath -- OsPath should be used but is currently not part of the newest LTS snapshot yet. for now, use old FilePath instead:
+  | FileDrop FilePath
   deriving (Eq, Show)
 
 -- | Status of input devices.

--- a/src/Monomer/Main/Core.hs
+++ b/src/Monomer/Main/Core.hs
@@ -332,7 +332,7 @@ mainLoop window fontManager config loopArgs = do
   let invertX = fromMaybe False (_apcInvertWheelX config)
   let invertY = fromMaybe False (_apcInvertWheelY config)
   let convertCfg = ConvertEventsCfg _mlOS dpr epr invertX invertY
-  let baseSystemEvents = convertEvents convertCfg mousePos eventsPayload
+  baseSystemEvents <- liftIO $ convertEvents convertCfg mousePos eventsPayload
 
 --  when newSecond $
 --    liftIO . putStrLnErr $ "Frames: " ++ show _mlFrameCount

--- a/src/Monomer/Main/Handlers.hs
+++ b/src/Monomer/Main/Handlers.hs
@@ -910,6 +910,8 @@ getTargetPath wenv root pressed overlay target event = case event of
     TextInput _                       -> pathEvent target
     -- Clipboard
     Clipboard _                       -> pathEvent target
+    -- FileDrop
+    FileDrop _                        -> pathEvent target
     -- Mouse/touch
     ButtonAction point _ BtnPressed _ -> pointEvent point
     ButtonAction _ _ BtnReleased _    -> pathEvent target


### PR DESCRIPTION
Dragging and dropping files or folders triggers a `FileDrop` `SystemEvent` for each item. Currently using `FilePath` instead of the newer `OsPath` because current LTS does not use the newest _filepath_ package (in GHC 9.6.2).

Implemented from SDL's native event `SDL.DropEvent`. Tested and works on macOS. The event handler `fileDropEvent` prints _FilePath_ to stdout, this should be removed and instead show this feature using an example program.

The `FileDrop` event is handy. You can for example send a file over internet, render an image or zip a folder by just dragging the item(s) into your Monomer window.