### PR TITLE
Update for ghc 9.6.2

### DIFF
--- a/monomer.cabal
+++ b/monomer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -183,7 +183,7 @@ library
     , formatting >=6.0 && <8.0
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
@@ -230,7 +230,7 @@ executable books
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
@@ -273,7 +273,7 @@ executable dev-test-app
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
@@ -315,7 +315,7 @@ executable generative
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -360,7 +360,7 @@ executable opengl
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -407,7 +407,7 @@ executable ticker
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
@@ -453,7 +453,7 @@ executable todo
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6
@@ -504,7 +504,7 @@ executable tutorial
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , random >=1.1 && <1.3
@@ -603,7 +603,7 @@ test-suite monomer-test
     , http-client >=0.6 && <0.9
     , lens >=4.16 && <6
     , monomer
-    , mtl >=2.1 && <2.3
+    , mtl >=2.1 && <3
     , nanovg >=0.8.1 && <1.0
     , process ==1.6.*
     , sdl2 >=2.5.0 && <2.6

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,7 @@ dependencies:
   - http-client >= 0.6 && < 0.9
   - JuicyPixels >= 3.2.9 && < 3.5
   - lens >= 4.16 && < 6
-  - mtl >= 2.1 && < 2.3
+  - mtl >= 2.1 && < 3
   - nanovg >= 0.8.1 && < 1.0
   - OpenGLRaw >= 3.3 && < 3.4
   - process >= 1.6 && < 1.7

--- a/src/Monomer/Main/Platform.hs
+++ b/src/Monomer/Main/Platform.hs
@@ -8,7 +8,7 @@ Portability : non-portable
 
 Helper functions for SDL platform related operations.
 -}
-{-# LANGUAGE Strict #-}
+{-# LANGUAGE ForeignFunctionInterface, Strict #-}
 
 module Monomer.Main.Platform (
   defaultWindowSize,
@@ -23,7 +23,8 @@ module Monomer.Main.Platform (
 ) where
 
 import Control.Exception (finally)
-import Control.Monad.Extra (whenJust)
+import Control.Monad (void)
+import Control.Monad.Extra (forM_, when, whenJust)
 import Control.Monad.State
 import Data.Maybe
 import Data.Text (Text)


### PR DESCRIPTION
This bumps the version of `mtl` to something that will work with the latest GHC. A few errors are also corrected.