### PR TITLE
Add fallback font support

### DIFF
--- a/cbits/fontmanager.c
+++ b/cbits/fontmanager.c
@@ -58,6 +58,21 @@ int fmCreateFontMem(FMcontext* ctx, const char* name, unsigned char* data, int d
 	return fonsAddFontMem(ctx->fs, name, data, dataSize, 1, 0);
 }
 
+extern int fonsAddFallbackFont(FONScontext* stash, int base, int fallback);
+
+int fmSetFontFallback(FMcontext* ctx, const char* baseName, const char* fallbackName) 
+{
+	int baseId = fonsGetFontByName(ctx->fs, baseName);
+	if (baseId == FONS_INVALID) {
+		return 0;
+	}
+	int fallbackId = fonsGetFontByName(ctx->fs, fallbackName);
+	if (fallbackId == FONS_INVALID) {
+		return 0;
+	}
+	return fonsAddFallbackFont(ctx->fs, baseId, fallbackId);
+}
+
 void fmSetScale(FMcontext* ctx, float scale) {
 	ctx->scale = scale;
 }

--- a/cbits/fontmanager.h
+++ b/cbits/fontmanager.h
@@ -41,6 +41,8 @@ int fmCreateFont(FMcontext* ctx, const char* name, const char* filename);
 
 int fmCreateFontMem(FMcontext* ctx, const char* name, unsigned char* data, int dataSize);
 
+int fmSetFontFallback(FMcontext* ctx, const char* baseName, const char* fallbackName);
+
 void fmSetScale(FMcontext* ctx, float scale);
 
 void fmFontFace(FMcontext* ctx, const char* font);

--- a/src/Monomer/Graphics/FFI.chs
+++ b/src/Monomer/Graphics/FFI.chs
@@ -149,6 +149,8 @@ deriving instance Storable FMContext
 
 {# fun unsafe fmCreateFontMem {`FMContext', withCString*`Text', allocCUStringLen*`ByteString'&} -> `Int' #}
 
+{# fun unsafe fmSetFontFallback {`FMContext', withCString*`Text', withCString*`Text'} -> `Int' #}
+
 {# fun unsafe fmSetScale {`FMContext', `Double'} -> `()' #}
 
 {# fun unsafe fmFontFace {`FMContext', withCString*`Text'} -> `()' #}

--- a/src/Monomer/Graphics/FontManager.hs
+++ b/src/Monomer/Graphics/FontManager.hs
@@ -29,7 +29,7 @@ import Monomer.Common.BasicTypes
 import Monomer.Graphics.FFI
 import Monomer.Graphics.Types
 import Monomer.Helper (putStrLnErr)
-import Monomer.Graphics.Lens (fontName, fontPath, fontBytes)
+import Monomer.Graphics.Lens (fontName, fontPath, baseName, fallbackName, fontBytes)
 
 -- | Creates a font manager instance.
 makeFontManager
@@ -102,6 +102,14 @@ newManager ctx = FontManager {..} where
       }
 
 loadFont :: FMContext -> [Text] -> FontDef -> IO [Text]
+loadFont ctx fonts fontDef@FontFallback{} = do
+  let base = fontDef ^. baseName
+  let fallback = fontDef ^. fallbackName
+  let fontsAreOk = elem base fonts && elem fallback fonts
+  res <- fmSetFontFallback ctx base fallback
+  when (res <= 0) $ do
+    putStrLnErr ("Failed to register font " ++ T.unpack fallback  ++ " as fallback for font " ++ T.unpack base)
+  return fonts
 loadFont ctx fonts fontDef = do
   res <- createFont fontDef
   if res >= 0
@@ -111,6 +119,7 @@ loadFont ctx fonts fontDef = do
     name = fontDef ^. fontName
     createFont FontDefFile{} = fmCreateFont ctx name (fontDef ^. fontPath)
     createFont FontDefMem{} = fmCreateFontMem ctx name (fontDef ^. fontBytes)
+    createFont _ = fail "unreachable"
 
 setFont :: FMContext -> Double -> Font -> FontSize -> FontSpace -> IO ()
 setFont ctx scale (Font name) (FontSize size) (FontSpace spaceH) = do

--- a/src/Monomer/Graphics/NanoVGRenderer.hs
+++ b/src/Monomer/Graphics/NanoVGRenderer.hs
@@ -363,6 +363,14 @@ newRenderer c rdpr envRef = Renderer {..} where
     req = ImageReq name def Nothing ImageDelete []
 
 loadFont :: VG.Context -> Set Text -> FontDef -> IO (Set Text)
+loadFont c fonts fontDef@FontFallback{} = do
+    res <- VG.addFallbackFont c baseName fallbackName
+    when (isNothing res) report
+    return fonts
+    where
+        baseName = fontDef ^. L.baseName
+        fallbackName = fontDef ^. L.fallbackName
+        report = putStrLnErr ("Failed to register font " ++ T.unpack fallbackName  ++ " as fallback for font " ++ T.unpack baseName)
 loadFont c fonts fontDef = do
   res <- createFont fontDef
   case res of
@@ -372,6 +380,7 @@ loadFont c fonts fontDef = do
     name = fontDef ^. L.fontName
     createFont FontDefFile{} = VG.createFont c name (VG.FileName $ fontDef ^. L.fontPath)
     createFont FontDefMem{} = VG.createFontMem c name (fontDef ^. L.fontBytes)
+    createFont FontFallback{} = fail "unreachable"
 
 setFont
   :: VG.Context

--- a/src/Monomer/Graphics/Types.hs
+++ b/src/Monomer/Graphics/Types.hs
@@ -54,6 +54,10 @@ data FontDef
     { _fntFontName :: !Text         -- ^ The logic name. Will be used when defining styles.
     , _fntFontBytes :: !ByteString  -- ^ The bytes of the loaded font.
     }
+  | FontFallback
+    { _fntBaseName :: !Text      -- ^ The name used when defining the base font
+    , _fntFallbackName :: !Text  -- ^ The name used when defining the fallback font
+    }
   deriving (Eq, Show, Generic)
 
 -- | The name of a loaded font.

--- a/src/Monomer/Main/Types.hs
+++ b/src/Monomer/Main/Types.hs
@@ -395,6 +395,15 @@ appFontDef name path = def {
 }
 
 {-|
+Set an available font as fallback for another available font.
+Both fonts are specified by the name used to define them
+-}
+appFontFallback :: Text -> Text -> AppConfig s e
+appFontFallback base fallback = def {
+  _apcFonts = [ FontFallback base fallback ]
+}
+
+{-|
 Available fonts to the application, loaded from the bytes in memory.
 Specifying no fonts will make it impossible to render text.
 


### PR DESCRIPTION
With this PR I'm adding support for fallback fonts:
```hs     
startApp model handleEvent buildUI config
where
    config = [
        ..
        appFontDef "Regular" "./assets/fonts/Roboto-Regular.ttf",
        appFontDef "Math" "/usr/share/fonts/gnu-free/FreeSerif.otf",
        appFontFallback "Regular" "Math",
        ...
        ]
    model = ...
```
An example of the result in a `textField`, with and without fallback font:
<img width="342" height="75" alt="image" src="https://github.com/user-attachments/assets/8cb3e2bc-c5c5-4796-8362-30332fccaa3b" />
This should address #304 .